### PR TITLE
Retain more DD information

### DIFF
--- a/bin/generate
+++ b/bin/generate
@@ -16,21 +16,6 @@ var file = process.argv[2]
 var res = process.argv[3]
 
 /**
- * Lovely resources
- */
-
-var resources = [
-  'Property',
-  'Member',
-  'Office',
-  'Contacts',
-  'Media',
-  'HistoryTransactional',
-  'SavedSearch',
-  'OpenHouse'
-]
-
-/**
  * Column names
  */
 
@@ -40,7 +25,7 @@ var keys = [
   'type',
   'maxLength',
   'maxPrecision',
-  'synonym',
+  'synonyms',
   'status',
   'lookup',
   'level',
@@ -48,7 +33,17 @@ var keys = [
   'bedesMapping',
   'path',
   'group',
-  'repeating'
+  'repeating',
+  'rid',
+  'resi',
+  'rlse',
+  'rinc',
+  'land',
+  'mobi',
+  'farm',
+  'coms',
+  'coml',
+  'buso'
 ]
 
 parse(file, res)
@@ -62,6 +57,8 @@ function parse (file, res) {
   out(src
     .map(toObject(keys))
     .map(toSchema)
+    .map(synonyms)
+    .map(classes(res))
     .map(primaryKey())
     .map(addEnums(enums))
     .map(cleanEmpty)
@@ -92,14 +89,35 @@ function toSchema (obj) {
   obj.type = parseType(obj.type)
   obj.maxLength = 'string' === obj.type? parseInt(obj.maxLength, 10) : undefined
   obj.repeating = 'Yes'===obj.repeating? true : undefined
-  obj.definition = undefined
-  obj.synonym = undefined
+  // obj.definition = undefined
   obj.status = undefined
   obj.group = undefined
   obj.bedesMapping = undefined
   obj.level = obj.level.toLowerCase()
   if (obj.lookup && obj.lookup.charAt(0) === '<') obj.lookup = undefined;
+  obj.rid = undefined
   return obj
+}
+
+function synonyms (obj) {
+  if (obj.synonyms) obj.synonyms = obj.synonyms
+    .split(',')
+    .map(function(s){ return s.trim() })
+  return obj
+}
+
+function classes (res) {
+  var classes = ['resi', 'rlse', 'rinc', 'land', 'mobi', 'farm', 'coms', 'coml', 'buso']
+  return function (obj) {
+    // classes only applies to properties!
+    if ('Property'===res) obj.classes = classes.filter(function(c){ return obj[c] === 'X' })
+
+    classes.forEach(function(c){
+      obj[c] = undefined
+    })
+
+    return obj
+  }
 }
 
 function primaryKey () {

--- a/bin/generate
+++ b/bin/generate
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
-var xlsx = require('xlsx-rows')
-var plural = require('plural')
+'use strict'
+
+const xlsx = require('xlsx-rows')
+const plural = require('plural')
 
 /**
  * Source file
@@ -19,7 +21,7 @@ var res = process.argv[3]
  * Column names
  */
 
-var keys = [
+const keys = [
   'key',
   'definition',
   'type',
@@ -49,16 +51,15 @@ var keys = [
 parse(file, res)
 
 function parse (file, res) {
-  var src = xlsx({file:file, sheetname:res})
-  var enums = xlsx({file:file, sheetname:'Enumerations'})
+  var src = xlsx({file: file, sheetname: res})
+  var enums = xlsx({file: file, sheetname: 'Enumerations'})
   src.shift()
   enums.shift()
 
   out(src
     .map(toObject(keys))
-    .map(toSchema)
-    .map(synonyms)
     .map(classes(res))
+    .map(toSchema)
     .map(primaryKey())
     .map(addEnums(enums))
     .map(cleanEmpty)
@@ -78,44 +79,40 @@ function out (obj) {
 function toObject (keys) {
   return function (vals) {
     var obj = {}
-    keys.forEach(function(k, i){
-      obj[k] = vals[i]
-    })
+    keys.forEach((k, i) => obj[k] = vals[i])
     return obj
   }
 }
 
 function toSchema (obj) {
-  obj.type = parseType(obj.type)
-  obj.maxLength = 'string' === obj.type? parseInt(obj.maxLength, 10) : undefined
-  obj.repeating = 'Yes'===obj.repeating? true : undefined
-  // obj.definition = undefined
-  obj.status = undefined
-  obj.group = undefined
-  obj.bedesMapping = undefined
-  obj.level = obj.level.toLowerCase()
-  if (obj.lookup && obj.lookup.charAt(0) === '<') obj.lookup = undefined;
-  obj.rid = undefined
-  return obj
+  return {
+    key: obj.key,
+    definition: obj.definition,
+    type: parseType(obj.type),
+    maxLength: parseInt(obj.maxLength, 10) || undefined,
+    maxPrecision: parseInt(obj.maxPrecision, 10) || undefined,
+    synonyms: synonyms(obj.synonyms),
+    lookup: (obj.lookup && obj.lookup.charAt(0) === '<') ? undefined : obj.lookup,
+    level: obj.level.toLowerCase(),
+    repeating: obj.repeating === 'Yes' ? true : undefined
+  }
 }
 
-function synonyms (obj) {
-  if (obj.synonyms) obj.synonyms = obj.synonyms
+function synonyms (arr) {
+  if (!arr) return
+  return arr
     .split(',')
-    .map(function(s){ return s.trim() })
-  return obj
+    .map((s) => s.trim())
+    .filter((s) => s.length)
 }
 
 function classes (res) {
-  var classes = ['resi', 'rlse', 'rinc', 'land', 'mobi', 'farm', 'coms', 'coml', 'buso']
+  const classes = ['resi', 'rlse', 'rinc', 'land', 'mobi', 'farm', 'coms', 'coml', 'buso']
   return function (obj) {
     // classes only applies to properties!
-    if ('Property'===res) obj.classes = classes.filter(function(c){ return obj[c] === 'X' })
-
-    classes.forEach(function(c){
-      obj[c] = undefined
-    })
-
+    if (res === 'Property') {
+      obj.classes = classes.filter((c) => obj[c] === 'X')
+    }
     return obj
   }
 }
@@ -137,7 +134,7 @@ function primaryKey () {
 
 function addEnums (arr) {
   var enums = {}
-  arr.forEach(function(row){
+  arr.forEach((row) => {
     if (!(row[0] in enums)) enums[row[0]] = []
     enums[row[0]].push(row[1])
   })
@@ -172,7 +169,7 @@ function repeatingFields (obj, i, arr) {
 
   // collect similar fields
   while (collect) {
-    j++;
+    j++
     fields.push(arr[j])
     collect = arr[j].key && arr[j].key.match(/(\w+)\[[Tt]ype\](\w+)$/)
     if (collect) {
@@ -181,13 +178,16 @@ function repeatingFields (obj, i, arr) {
     }
   }
 
-  keys.forEach(function(k, i){
+  keys.forEach((k, i) => {
     subdoc[k] = fields[i]
     delete subdoc[k].repeating
     delete subdoc[k].key
   })
 
-  obj.subdoc = {key:plural(shortName),body:[subdoc]}
+  obj.subdoc = {
+    key: plural(shortName),
+    body: [subdoc]
+  }
 
   return obj
 }
@@ -199,7 +199,7 @@ function repeatingFields (obj, i, arr) {
 function cleanEmpty (obj) {
   Object
     .keys(obj)
-    .forEach(function(k){
+    .forEach((k) => {
       if (undefined === obj[k]) delete obj[k]
     })
   return obj
@@ -209,7 +209,7 @@ function cleanEmpty (obj) {
  * Turn array into object
  */
 
-function reduce (obj, el){
+function reduce (obj, el) {
   if (!el.key) return obj
   obj[el.key] = el
   if (el.subdoc) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 /**
  * Expose Schemas
  */
-
 exports.openhouse = require('./lib/openhouse');
 exports.property = require('./lib/property');
 exports.office = require('./lib/office');

--- a/lib/contact.json
+++ b/lib/contact.json
@@ -1,165 +1,194 @@
 {
   "ContactKey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the ContactKey is the system unique identifier from the system that the record was retrieved. This may be identical to the related xxxId.",
     "type": "string",
     "maxLength": 255,
+    "synonyms": [
+      "RID"
+    ],
     "level": "silver",
-    "path": "/Contacts",
     "primary": true
   },
   "ContactKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the ContactKey is the system unique identifier from the system that the record was retrieved. This may be identical to the related xxxId.  This is the numeric only key and used as an alternative to the ContactKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Contacts"
+    "maxLength": 255,
+    "synonyms": [
+      "RID"
+    ],
+    "level": "platinum"
   },
   "ContactLoginId": {
+    "definition": "The local, well-known identifier for the contact. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system and is used by the Contact to logon to a client portal in that system.",
     "type": "string",
     "maxLength": 25,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "ContactPassword": {
+    "definition": "A client password that the member whishes to share with other systems.  Normal security considerations apply and are the responsibility of the entity utilizing this field.",
     "type": "string",
     "maxLength": 25,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "OriginatingSystemContactKey": {
+    "definition": "The system key, a unique record identifier, from the Originating system.  The Originating system is the system with authoritative control over the record.  For example, the Multiple Listing Service where the Contact was input.  There may be cases where the Source System (how you received the record) is not the Originating System.  See Source System Key for more information. ",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Contacts"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "silver"
   },
   "OriginatingSystemName": {
+    "definition": "The name of the Originating record provider.  Most commonly the name of the MLS. The place where the Contact is originally input by the member.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Contacts"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "silver"
   },
   "OriginatingSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Originating record provider.  The Originating system is the system with authoritative control over the record.  For example; the name of the MLS where the Contact was input.  In cases where the Originating system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/Contacts"
+    "level": "platinum"
   },
   "SourceSystemContactKey": {
+    "definition": "The system key, a unique record identifier, from the Source System.  The Source System is the system from which the record was directly received.  In cases where the Source System was not where the record originated (the authoritative system), see the Originating System fields. ",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Contacts"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "silver"
   },
   "SourceSystemName": {
+    "definition": "The name of the immediate record provider.  The system from which the record was directly received.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Contacts"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "silver"
   },
   "SourceSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Source record provider.  The source system is the system from which the record was directly received.  In cases where the source system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/Contacts"
+    "synonyms": [
+      "MLSID"
+    ],
+    "level": "platinum"
   },
   "OwnerMemberKey": {
+    "definition": "The unique identifier (key) of the member owning the contact. This is a foreign key relating to the Member resource's MemberKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "OwnerMemberKeyNumeric": {
+    "definition": "The unique identifier (key) of the member owning the contact. This is a foreign key relating to the Member resource's MemberKey.  This is the numeric only key and used as an alternative to the OwnerMemberKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Contacts"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "OwnerMemberID": {
+    "definition": "The local, well-known identifier for the member owning the contact.",
     "type": "string",
     "maxLength": 25,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "NamePrefix": {
+    "definition": "Prefix to the name (e.g. Dr. Mr. Ms. etc.)",
     "type": "string",
     "maxLength": 10,
-    "level": "silver",
-    "path": "/Contacts"
+    "synonyms": [
+      "Salutation",
+      "Title"
+    ],
+    "level": "silver"
   },
   "FirstName": {
+    "definition": "The first name of the Member.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "MiddleName": {
+    "definition": "The middle name of the Member.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "LastName": {
+    "definition": "The last name of the Member.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "NameSuffix": {
+    "definition": "Suffix to the surname (e.g. Esq.,  Jr.,  III etc.)",
     "type": "string",
     "maxLength": 10,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "FullName": {
+    "definition": "The full name of the Member. (First Middle Last) or a alternate full name.",
     "type": "string",
     "maxLength": 150,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "Nickname": {
+    "definition": "An alternate name used by the Member, usually as a substitute for the first name.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "ReferredBy": {
+    "definition": "Name of the person who referred the contact.",
     "type": "string",
     "maxLength": 150,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "JobTitle": {
+    "definition": "The title or position of the member within their organization.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "Notes": {
+    "definition": "Notes about the client.",
     "type": "string",
     "maxLength": 1024,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "HomeAddress1": {
+    "definition": "The street number, direction, name and suffix of the contact's home.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "HomeAddress2": {
+    "definition": "The unit/suite number of the contact's home.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "HomeCity": {
+    "definition": "The city of the contact's home.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "HomeStateOrProvince": {
+    "definition": "The state or province in which the contact's home is addressed.",
     "type": "string",
     "maxLength": 2,
     "lookup": "StateOrProvince",
     "level": "silver",
-    "path": "/Contacts",
     "enum": [
       "AK",
       "AL",
@@ -229,35 +258,42 @@
     ]
   },
   "HomePostalCode": {
+    "definition": "The postal code of the contact's home.",
     "type": "string",
     "maxLength": 10,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "HomePostalCodePlus4": {
+    "definition": "The extension of the postal/zip code.  i.e. +4",
     "type": "string",
     "maxLength": 4,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "HomeCarrierRoute": {
+    "definition": "The group of addresses to which the USPS assigns the same code to aid in mail delivery. For the USPS, these codes are 9 digits: 5 numbers for the ZIP Code, one letter for the carrier route type, and 3 numbers for the carrier route number.",
     "type": "string",
     "maxLength": 9,
-    "level": "silver",
-    "path": "/Contacts"
+    "synonyms": [
+      "RR",
+      "CR"
+    ],
+    "level": "silver"
   },
   "HomeCountyOrParish": {
+    "definition": "The county or parish in which the contact's home is addressed.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "synonyms": [
+      "County"
+    ],
+    "level": "silver"
   },
   "HomeCountry": {
+    "definition": "The country abbreviation in a postal address.",
     "type": "string",
     "maxLength": 2,
     "lookup": "Country",
     "level": "silver",
-    "path": "/Contacts",
     "enum": [
       "AF",
       "AL",
@@ -509,29 +545,29 @@
     ]
   },
   "WorkAddress1": {
+    "definition": "The street number, direction, name and suffix of the contact's work.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "WorkAddress2": {
+    "definition": "The unit/suite number of the contact's work.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "WorkCity": {
+    "definition": "The city of the contact's work.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "WorkStateOrProvince": {
+    "definition": "The state or province in which the contact's work is addressed.",
     "type": "string",
     "maxLength": 2,
     "lookup": "StateOrProvince",
     "level": "silver",
-    "path": "/Contacts",
     "enum": [
       "AK",
       "AL",
@@ -601,35 +637,42 @@
     ]
   },
   "WorkPostalCode": {
+    "definition": "The postal code of the contact's work.",
     "type": "string",
     "maxLength": 10,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "WorkPostalCodePlus4": {
+    "definition": "The extension of the postal/zip code.  i.e. +4",
     "type": "string",
     "maxLength": 4,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "WorkCarrierRoute": {
+    "definition": "The group of addresses to which the USPS assigns the same code to aid in mail delivery. For the USPS, these codes are 9 digits: 5 numbers for the ZIP Code, one letter for the carrier route type, and 3 numbers for the carrier route number.",
     "type": "string",
     "maxLength": 9,
-    "level": "silver",
-    "path": "/Contacts"
+    "synonyms": [
+      "RR",
+      "CR"
+    ],
+    "level": "silver"
   },
   "WorkCountyOrParish": {
+    "definition": "The county or parish in which the contact's work is addressed.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "synonyms": [
+      "County"
+    ],
+    "level": "silver"
   },
   "WorkCountry": {
+    "definition": "The country abbreviation in a postal address.",
     "type": "string",
     "maxLength": 2,
     "lookup": "Country",
     "level": "silver",
-    "path": "/Contacts",
     "enum": [
       "AF",
       "AL",
@@ -881,29 +924,29 @@
     ]
   },
   "OtherAddress1": {
+    "definition": "The other street number, direction, name and suffix of the contact.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "OtherAddress2": {
+    "definition": "The other unit/suite number of the contact.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "OtherCity": {
+    "definition": "The other city of the contact.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "OtherStateOrProvince": {
+    "definition": "The other state or province in which the contact is addressed.",
     "type": "string",
     "maxLength": 2,
     "lookup": "StateOrProvince",
     "level": "silver",
-    "path": "/Contacts",
     "enum": [
       "AK",
       "AL",
@@ -973,35 +1016,42 @@
     ]
   },
   "OtherPostalCode": {
+    "definition": "The other postal code of the contact.",
     "type": "string",
     "maxLength": 10,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "OtherPostalCodePlus4": {
+    "definition": "The other extension of the postal/zip code.  i.e. +4",
     "type": "string",
     "maxLength": 4,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "OtherCarrierRoute": {
+    "definition": "The group of addresses to which the USPS assigns the same code to aid in mail delivery. For the USPS, these codes are 9 digits: 5 numbers for the ZIP Code, one letter for the carrier route type, and 3 numbers for the carrier route number.",
     "type": "string",
     "maxLength": 9,
-    "level": "silver",
-    "path": "/Contacts"
+    "synonyms": [
+      "RR",
+      "CR"
+    ],
+    "level": "silver"
   },
   "OtherCountyOrParish": {
+    "definition": "The other county or parish in which contact is addressed.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "synonyms": [
+      "County"
+    ],
+    "level": "silver"
   },
   "OtherCountry": {
+    "definition": "The other country abbreviation in a postal address.",
     "type": "string",
     "maxLength": 2,
     "lookup": "Country",
     "level": "silver",
-    "path": "/Contacts",
     "enum": [
       "AF",
       "AL",
@@ -1253,112 +1303,112 @@
     ]
   },
   "PreferredAddress": {
+    "definition": "A list of the address options Home, Work and Other used to determine the address preferred by the client.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "PreferredPhone": {
+    "definition": "A list of the phone options Office, Mobile, Direct, Voicemail, Other used to determine the phone preferred by the client.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "Email": {
+    "definition": "The preferred Email address of the contact.",
     "type": "string",
     "maxLength": 80,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "Email2": {
+    "definition": "The secondary email address of the contact.",
     "type": "string",
     "maxLength": 80,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "Email3": {
+    "definition": "The tertiary email address of the contact.",
     "type": "string",
     "maxLength": 80,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "OfficePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "OfficePhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "MobilePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "DirectPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "HomePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "HomeFax": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "BusinessFax": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "Pager": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "VoiceMail": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "VoiceMailExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "TollFreePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "PhoneTTYTTD": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "OtherPhoneType": {
+    "definition": "The type of \"other\" phone that does not already exist in the given phone fields or if a second of any type of phone field is needed.  i.e. HomePhone2,  BrothersPhone, etc.  This is used as the list of options for the Other Phone repeating elements. ",
     "type": "string",
     "maxLength": 25,
     "level": "silver",
-    "path": "/Contacts",
     "repeating": true
   },
   "OtherPhones": [
@@ -1367,36 +1417,36 @@
         "type": "string"
       },
       "Number": {
+        "definition": "The \"other\" phone option allowing members to convey additional phone numbers other than those already covered by the HomePhone, VoiceMail, etc., fields.  This is a repeating element.  Use the OtherPhoneType for a selection of additional phone types.",
         "type": "string",
         "maxLength": 16,
-        "level": "silver",
-        "path": "/Contacts"
+        "level": "silver"
       },
       "Ext": {
+        "definition": "The \"other\" phone option allowing members to convey additional phone numbers other than those already covered by the VoiceMailExt, OfficePhoneExt, etc., fields.  This is a repeating element.  Use the OtherPhoneType for a selection of additional phone types.",
         "type": "string",
         "maxLength": 10,
-        "level": "silver",
-        "path": "/Contacts"
+        "level": "silver"
       }
     }
   ],
   "Company": {
+    "definition": "The contact's company or employer.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "Department": {
+    "definition": "The department in which the contact works.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "SocialMediaType": {
+    "definition": "A list of types of sites, blog, social media, the Member URL or ID is referring to.  i.e. Website, Blog, Facebook, Twitter, LinkedIn, Skype, etc.,  This list is used to populate the Type with repeating Social Media URL or ID types.",
     "type": "string",
     "maxLength": 25,
     "level": "silver",
-    "path": "/Contacts",
     "repeating": true
   },
   "SocialMedias": [
@@ -1405,96 +1455,101 @@
         "type": "string"
       },
       "UrlOrId": {
+        "definition": "The website URL or ID of social media site or account of the member.  This is a repeating element.  Replace [Type] with any of the options from the SocialMediaType field to create a unique field for that type of social media.  For example: SocialMediaFacebookUrlOrID, SocialMediaSkypeUrlOrID, etc.",
         "type": "string",
         "maxLength": 8000,
-        "level": "silver",
-        "path": "/Contacts"
+        "level": "silver"
       }
     }
   ],
   "Birthdate": {
+    "definition": "The birthday of the contact; month, day and year.",
     "type": "date",
-    "level": "silver",
-    "path": "/Contacts"
+    "maxLength": 24,
+    "level": "silver"
   },
   "Anniversary": {
+    "definition": "The wedding anniversary of the contact; month, day and year.",
     "type": "date",
-    "level": "silver",
-    "path": "/Contacts"
+    "maxLength": 24,
+    "level": "silver"
   },
   "OriginalEntryTimestamp": {
+    "definition": "Date/time the contact record was originally input into the source system.",
     "type": "date",
-    "level": "silver",
-    "path": "/Contacts"
+    "maxLength": 27,
+    "level": "silver"
   },
   "ModificationTimestamp": {
+    "definition": "Date/time the contact record was last modified.",
     "type": "date",
-    "level": "silver",
-    "path": "/Contacts"
+    "maxLength": 27,
+    "level": "silver"
   },
   "UserDefinedFieldName[#]": {
+    "definition": "[#] This field is a repeating element.  If this field is repeated, add 1, 2, 3, etc., to the end of the field.",
     "type": "string",
     "maxLength": 500,
     "level": "silver",
-    "path": "/Contacts",
     "repeating": true
   },
   "UserDefinedFieldValue[#]": {
+    "definition": "[#] This field is a repeating element.  If this field is repeated, add 1, 2, 3, etc., to the end of the field.",
     "type": "string",
     "maxLength": 500,
     "level": "silver",
-    "path": "/Contacts",
     "repeating": true
   },
   "AssistantName": {
+    "definition": "Name of the contact's assistant.",
     "type": "string",
     "maxLength": 150,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "AssistantPhone": {
+    "definition": "Phone number of the contact's assistant.",
     "type": "string",
     "maxLength": 16,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "AssistantPhoneExt": {
+    "definition": "Phone number extension of the contact's assistant.",
     "type": "string",
     "maxLength": 10,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "AssistantEmail": {
+    "definition": "Email address of the contact's assistant.",
     "type": "string",
     "maxLength": 80,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "SpousePartnerName": {
+    "definition": "The contact's spouse or partner.",
     "type": "string",
     "maxLength": 150,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "Children": {
+    "definition": "A list of the names of the contact's children in a comma separated list.",
     "type": "string",
     "maxLength": 150,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "Gender": {
+    "definition": "The contact's gender.",
     "type": "string",
     "maxLength": 6,
-    "level": "silver",
-    "path": "/Contacts"
+    "level": "silver"
   },
   "Language": {
+    "definition": "The languages spoken by the contact.",
     "type": [
       "string"
     ],
+    "maxLength": 150,
     "lookup": "Languages",
     "level": "silver",
-    "path": "/Contacts",
     "enum": [
       "Abkhazian",
       "Afar",
@@ -1689,23 +1744,34 @@
     ]
   },
   "Groups": {
+    "definition": "Also knows as Tags, Categories, Circles, ",
     "type": [
       "string"
     ],
-    "level": "silver",
-    "path": "/Contacts"
+    "maxLength": 150,
+    "synonyms": [
+      "Tags",
+      "Groups",
+      "Categories",
+      "Types"
+    ],
+    "level": "silver"
   },
   "ContactStatus": {
+    "definition": "The status of the contact.  Active, Inactive, On Vacation, Deleted, etc., ",
     "type": "string",
     "maxLength": 25,
-    "level": "silver",
-    "path": "/Contacts"
+    "synonyms": [
+      "ChoiceList"
+    ],
+    "level": "silver"
   },
   "ContactType": {
+    "definition": "The type of contact.  i.e. Business, Friend, Family, Prospect, Ready to Buy, etc.",
     "type": [
       "string"
     ],
-    "level": "silver",
-    "path": "/Contacts"
+    "maxLength": 255,
+    "level": "silver"
   }
 }

--- a/lib/historytransactional.json
+++ b/lib/historytransactional.json
@@ -1,75 +1,94 @@
 {
   "HistoryTransactionalKey": {
+    "definition": "A unique identifier for this record from the immediate source. This may be a number, or string that can include URI or other forms.  This is the system you are connecting to and not necessarily the original source of the record.",
     "type": "string",
     "maxLength": 255,
     "level": "silver",
-    "path": "/HistoryTransactional",
     "primary": true
   },
   "HistoryTransactionalKeyNumeric": {
+    "definition": "A unique identifier for this record from the immediate source. This may be a number, or string that can include URI or other forms.  This is the system you are connecting to and not necessarily the original source of the record.  This is the numeric only key and used as an alternative to the HistoryTransactionalKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/HistoryTransactional"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "OriginatingSystemHistoryKey": {
+    "definition": "The system key, a unique record identifier, from the Originating system.  The Originating system is the system with authoritative control over the record.  For example, the Multiple Listing Service where the History was input.  There may be cases where the Source System (how you received the record) is not the Originating System.  See Source System Key for more information. ",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/HistoryTransactional"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "silver"
   },
   "OriginatingSystemName": {
+    "definition": "The name of the Originating record provider.  Most commonly the name of the MLS. The place where the History is originally input.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/HistoryTransactional"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "silver"
   },
   "OriginatingSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Originating record provider.  The Originating system is the system with authoritative control over the record.  For example; the name of the MLS where the History was input.  In cases where the Originating system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/HistoryTransactional"
+    "level": "platinum"
   },
   "SourceSystemHistoryKey": {
+    "definition": "The system key, a unique record identifier, from the Source System.  The Source System is the system from which the record was directly received.  In cases where the Source System was not where the record originated (the authoritative system), see the Originating System fields. ",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/HistoryTransactional"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "silver"
   },
   "SourceSystemName": {
+    "definition": "The name of the History record provider.  The system from which the record was directly received.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/HistoryTransactional"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "silver"
   },
   "SourceSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Source record provider.  The source system is the system from which the record was directly received.  In cases where the source system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/HistoryTransactional"
+    "synonyms": [
+      "MLSID"
+    ],
+    "level": "platinum"
   },
   "ChangedByMemberID": {
+    "definition": "The local, well-know identifier of the member (user) who made the change.",
     "type": "string",
     "maxLength": 25,
-    "level": "silver",
-    "path": "/HistoryTransactional"
+    "level": "silver"
   },
   "ChangedByMemberKey": {
+    "definition": "The unique identifier of the member (user) who made the change.  This is a foreign key relating to the Member resource's MemberKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/HistoryTransactional"
+    "level": "silver"
   },
   "ChangedByMemberKeyNumeric": {
+    "definition": "The unique identifier of the member (user) who made the change.  This is a foreign key relating to the Member resource's MemberKey.  This is the numeric only key and used as an alternative to the ChangedByMemberKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/HistoryTransactional"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "ChangeType": {
+    "definition": "Description of the last major change on the listing, i.e. “price reduction”, “back on market”, etc.  May be used to display on a summary view of listing results to quickly identify listings that have had major changes recently.",
     "type": "string",
     "maxLength": 255,
     "lookup": "ChangeType",
     "level": "silver",
-    "path": "/HistoryTransactional",
     "enum": [
       "Active",
       "Active Under Contract",
@@ -86,45 +105,47 @@
     ]
   },
   "ModificationTimestamp": {
+    "definition": "Timestamp of the last major change on the listing (see also MajorChangeType).",
     "type": "date",
-    "level": "silver",
-    "path": "/HistoryTransactional"
+    "maxLength": 27,
+    "level": "silver"
   },
   "FieldKey": {
+    "definition": "The unique identifier of the field whose data is being changed.  This is a foreign key relating to the field found in the resource per the ResourceName.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/HistoryTransactional"
+    "level": "silver"
   },
   "FieldKeyNumeric": {
+    "definition": "The unique identifier of the field whose data is being changed.  This is a foreign key relating to the field found in the resource per the ResourceName.  This is the numeric only key and used as an alternative to the FieldKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/HistoryTransactional"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "FieldName": {
+    "definition": "The name of the field whose data is being changed.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/HistoryTransactional"
+    "level": "silver"
   },
   "PreviousValue": {
+    "definition": "The value found in the named field prior to the change represented by this record.",
     "type": "string",
     "maxLength": 8000,
-    "level": "silver",
-    "path": "/HistoryTransactional"
+    "level": "silver"
   },
   "NewValue": {
+    "definition": "The new value applied to the named field.",
     "type": "string",
     "maxLength": 8000,
-    "level": "silver",
-    "path": "/HistoryTransactional"
+    "level": "silver"
   },
   "ClassName": {
+    "definition": "Name of the class which this history record applies.",
     "type": "string",
     "maxLength": 255,
     "lookup": "ClassName",
     "level": "silver",
-    "path": "/HistoryTransactional",
     "enum": [
       "Business Opportunity",
       "Commercial Lease",
@@ -146,11 +167,11 @@
     ]
   },
   "ResourceName": {
+    "definition": "The name of the resource which this history record applies.",
     "type": "string",
     "maxLength": 255,
     "lookup": "ResourceName",
     "level": "silver",
-    "path": "/HistoryTransactional",
     "enum": [
       "Property",
       "Member",
@@ -159,20 +180,37 @@
     ]
   },
   "ResourceRecordKey": {
+    "definition": "The primary key of the related record from the source resource. For example the ListingKey, AgentKey, OfficeKey, etc.  This is the system you are connecting to and not necessarily the original source of the record.  This is a foreign key from the resource selected in the ResourceName field.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/HistoryTransactional"
+    "synonyms": [
+      "SystemUniqueID",
+      "ImmediateSourceID"
+    ],
+    "level": "silver"
   },
   "ResourceRecordKeyNumeric": {
+    "definition": "The primary key of the related record from the source resource. For example the ListingKey, AgentKey, OfficeKey, etc.  This is the system you are connecting to and not necessarily the original source of the record.  This is a foreign key from the resource selected in the ResourceName field.  This is the numeric only key and used as an alternative to the ResourceRecordKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/HistoryTransactional"
+    "maxLength": 255,
+    "synonyms": [
+      "SystemUniqueID",
+      "ImmediateSourceID"
+    ],
+    "level": "platinum"
   },
   "ResourceRecordID": {
+    "definition": "The well known identifier of the related record from the source resource. The value may be identical to that of the Listing Key, but the Listing ID is intended to be the value used by a human to retrieve the information about a specific listing. In a multiple originating system or a merged system, this value may not be unique and may require the use of the provider system to create a synthetic unique value.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/HistoryTransactional"
+    "synonyms": [
+      "MLNumber",
+      "MLSNumber",
+      "ListingNumber",
+      "AgentID",
+      "OfficeID",
+      "ContactID"
+    ],
+    "level": "silver"
   }
 }

--- a/lib/media.json
+++ b/lib/media.json
@@ -1,98 +1,142 @@
 {
   "MediaKey": {
+    "definition": "A unique identifier for this record from the immediate source. This may be a number, or string that can include URI or other forms.  This is the system you are connecting to and not necessarily the original source of the record.",
     "type": "string",
     "maxLength": 255,
+    "synonyms": [
+      "SystemUniqueID",
+      "ImmediateSourceID"
+    ],
     "level": "core",
-    "path": "/Media",
     "primary": true
   },
   "MediaKeyNumeric": {
+    "definition": "A unique identifier for this record from the immediate source. This may be a number, or string that can include URI or other forms.  This is the system you are connecting to and not necessarily the original source of the record.  This is the numeric only key and used as an alternative to the MediaKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Media"
+    "maxLength": 255,
+    "synonyms": [
+      "SystemUniqueID",
+      "ImmediateSourceID"
+    ],
+    "level": "platinum"
   },
   "ResourceRecordKey": {
+    "definition": "The primary key of the related record from the source resource. For example the ListingKey, AgentKey, OfficeKey, TeamKey, etc.  This is the system you are connecting to and not necessarily the original source of the record.  This is a foreign key from the resource selected in the ResourceName field.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Media"
+    "synonyms": [
+      "SystemUniqueID",
+      "ImmediateSourceID"
+    ],
+    "level": "core"
   },
   "ResourceRecordKeyNumeric": {
+    "definition": "The primary key of the related record from the source resource. For example the ListingKey, AgentKey, OfficeKey, TeamKey, etc.  This is the system you are connecting to and not necessarily the original source of the record.  This is a foreign key from the resource selected in the ResourceName field.  This is the numeric only key and used as an alternative to the ResourceRecordKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Media"
+    "maxLength": 255,
+    "synonyms": [
+      "SystemUniqueID",
+      "ImmediateSourceID"
+    ],
+    "level": "platinum"
   },
   "ResourceRecordID": {
+    "definition": "The well known identifier of the related record from the source resource. The value may be identical to that of the Listing Key, but the Listing ID is intended to be the value used by a human to retrieve the information about a specific listing. In a multiple originating system or a merged system, this value may not be unique and may require the use of the provider system to create a synthetic unique value.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Media"
+    "synonyms": [
+      "MLNumber",
+      "MLSNumber",
+      "ListingNumber",
+      "AgentID",
+      "OfficeID",
+      "ContactID"
+    ],
+    "level": "core"
   },
   "OriginatingSystemMediaKey": {
+    "definition": "The system key, a unique record identifier, from the Originating system.  The Originating system is the system with authoritative control over the record.  For example, the Multiple Listing Service where the Media was input.  There may be cases where the Source System (how you received the record) is not the Originating System.  See Source System Key for more information. ",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Media"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "core"
   },
   "OriginatingSystemName": {
+    "definition": "The name of the Originating record provider.  Most commonly the name of the MLS. The place where the Media is originally input by the member.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "bronze",
-    "path": "/Media"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "bronze"
   },
   "OriginatingSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Originating record provider.  The Originating system is the system with authoritative control over the record.  For example; the name of the MLS where the Media was input.  In cases where the Originating system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/Media"
+    "level": "platinum"
   },
   "SourceSystemMediaKey": {
+    "definition": "The system key, a unique record identifier, from the Source System.  The Source System is the system from which the record was directly received.  In cases where the Source System was not where the record originated (the authoritative system), see the Originating System fields. ",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Media"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "silver"
   },
   "SourceSystemName": {
+    "definition": "The name of the immediate record provider.  The system from which the record was directly received.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Media"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "silver"
   },
   "SourceSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Source record provider.  The source system is the system from which the record was directly received.  In cases where the source system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/Media"
+    "synonyms": [
+      "MLSID"
+    ],
+    "level": "platinum"
   },
   "MediaObjectID": {
+    "definition": "ID of the image, supplement or other object specified by the given media record.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Media"
+    "level": "core"
   },
   "ChangedByMemberID": {
+    "definition": "ID of the user, agent, member, etc., that uploaded the media this record refers to.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Media"
+    "level": "core"
   },
   "ChangedByMemberKey": {
+    "definition": "The primary key of the member who uploaded the media this record refers to.  This is a foreign key relating to the Member resource's MemberKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Media"
+    "level": "core"
   },
   "ChangedByMemberKeyNumeric": {
+    "definition": "The primary key of the member who uploaded the media this record refers to.  This is a foreign key relating to the Member resource's MemberKey.  This is the numeric only key and used as an alternative to the ChangedByMemberKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Media"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "MediaCategory": {
+    "definition": "Category describing the , Photos, Documents, Video, Unbranded Virtual Tour, Branded Virtual Tour, Floor Plan, Logo",
     "type": "string",
     "maxLength": 50,
     "lookup": "MediaCategory",
     "level": "bronze",
-    "path": "/Media",
     "enum": [
       "Photo",
       "Video",
@@ -106,11 +150,14 @@
     ]
   },
   "MediaType": {
+    "definition": "Media Types as defined by IANA.\r\nhttp://www.iana.org/assignments/media-types/index.html.  Note that the former name of MimeType, used by both IANA and RESO may still be in use by some systems/entities.",
     "type": "string",
     "maxLength": 50,
+    "synonyms": [
+      "MimeType"
+    ],
     "lookup": "MediaType",
     "level": "bronze",
-    "path": "/Media",
     "enum": [
       "gif",
       "jpeg",
@@ -130,11 +177,11 @@
     ]
   },
   "ImageOf": {
+    "definition": "When the media is an image, a list of possible matches such as kitchen, bathroom, front of structure, etc.  This field may be used to identify a required image under association or MLS rules.",
     "type": "string",
     "maxLength": 50,
     "lookup": "ImageOf",
     "level": "platinum",
-    "path": "/Media",
     "enum": [
       "Aerial View",
       "Atrium",
@@ -216,72 +263,95 @@
     ]
   },
   "ShortDescription": {
+    "definition": "The short text given to summarize the object.  Commonly used as the short description displayed under a photo.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Media"
+    "synonyms": [
+      "Caption",
+      "Name"
+    ],
+    "level": "bronze"
   },
   "LongDescription": {
+    "definition": "The full robust description of the object.",
     "type": "string",
     "maxLength": 1024,
-    "level": "bronze",
-    "path": "/Media"
+    "synonyms": [
+      "FullDescription"
+    ],
+    "level": "bronze"
   },
   "ModificationTimestamp": {
+    "definition": "The transactional timestamp automatically recorded by the MLS system representing the date/time the media record was last modified.",
     "type": "date",
-    "level": "core",
-    "path": "/Media"
+    "maxLength": 27,
+    "synonyms": [
+      "ModificationDateTime",
+      "DateTimeModified",
+      "ModDate",
+      "DateMod",
+      "UpdateDate",
+      "UpdateTimestamp"
+    ],
+    "level": "core"
   },
   "MediaModificationTimestamp": {
+    "definition": "This timestamp is updated when a change to the object has been made, which may differ from a change to the Media Resource.",
     "type": "date",
-    "level": "bronze",
-    "path": "/Media"
+    "maxLength": 27,
+    "synonyms": [
+      "MediaTimestamp"
+    ],
+    "level": "bronze"
   },
   "MediaURL": {
+    "definition": "The URI to the media file referenced by this record.",
     "type": "string",
     "maxLength": 8000,
-    "level": "core",
-    "path": "/Media"
+    "level": "core"
   },
   "MediaHTML": {
+    "definition": "The JavaScript or other method to embed a video, image, virtual tour or other media.",
     "type": "string",
     "maxLength": 8500,
-    "level": "bronze",
-    "path": "/Media"
+    "level": "bronze"
   },
   "Order": {
+    "definition": "Only a positive integer including zero.  Element zero is the primary photo per RETS convention.",
     "type": "number",
-    "level": "core",
-    "path": "/Media"
+    "maxLength": 4,
+    "level": "core"
   },
   "Group": {
+    "definition": "A placeholder for media classification such as elevation, exterior, interior, community, view, plan, plat.  The purpose is to allow media items to be grouped.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Media"
+    "level": "bronze"
   },
   "ImageWidth": {
+    "definition": "The width of the image expressed in pixels.",
     "type": "number",
-    "level": "bronze",
-    "path": "/Media"
+    "maxLength": 8,
+    "level": "bronze"
   },
   "ImageHeight": {
+    "definition": "The height of the image expressed in pixels.",
     "type": "number",
-    "level": "bronze",
-    "path": "/Media"
+    "maxLength": 8,
+    "level": "bronze"
   },
   "ImageSizeDescription": {
+    "definition": "A text description of the size of the image.  i.e. Small, Thumbnail, Medium, Large, X-Large.  The largest image must be described as \"Largest\".  Thumbnail must also be included.  Pick List will remain open/extendable.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Media"
+    "level": "bronze"
   },
   "ResourceName": {
+    "definition": "The resource or table of the listing or other record the media relates to.  i.e. Property, Member, Office, etc.",
     "type": "string",
     "maxLength": 50,
     "lookup": "ResourceName",
     "level": "core",
-    "path": "/Media",
     "enum": [
       "Property",
       "Member",
@@ -290,11 +360,11 @@
     ]
   },
   "ClassName": {
+    "definition": "The class or table of the listing or other record the media.  Residential, Lease, Agent, Office, Contact, etc.",
     "type": "string",
     "maxLength": 50,
     "lookup": "ClassName",
     "level": "bronze",
-    "path": "/Media",
     "enum": [
       "Business Opportunity",
       "Commercial Lease",
@@ -316,21 +386,22 @@
     ]
   },
   "Permission": {
+    "definition": "Public, Private, IDX, VOW, Office Only, Firm Only, Agent Only, ",
     "type": [
       "string"
     ],
-    "level": "bronze",
-    "path": "/Media"
+    "maxLength": 255,
+    "level": "bronze"
   },
   "MediaStatus": {
+    "definition": "The status of the media item referenced by this record.  (Updated, Deleted, etc.,_   ",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Media"
+    "level": "bronze"
   },
   "PreferredPhotoYN": {
+    "definition": "When set to true, the media record in question is the preferred photo.  This will typically mean the photo to be shown when only one of the photos is to be displayed.",
     "type": "boolean",
-    "level": "platinum",
-    "path": "/Media"
+    "level": "platinum"
   }
 }

--- a/lib/member.json
+++ b/lib/member.json
@@ -1,213 +1,238 @@
 {
   "MemberKey": {
+    "definition": "A unique identifier for this record from the immediate source. This is a string that can include URI or other forms.  Alternatively use the MemberKeyNumeric for a numeric only key field.  This is the local key of the system.  When records are received from other systems, a local key is commonly applied.  If conveying the original keys from the source or originating systems, see SourceSystemMemberKey and OriginatingSystemMemberKey.",
     "type": "string",
     "maxLength": 255,
     "level": "core",
-    "path": "/Member",
     "primary": true
   },
   "MemberKeyNumeric": {
+    "definition": "A unique identifier for this record from the immediate source. This is the numeric only key and used as an alternative to the MemberKey fields.  This is the local key of the system.  When records are received from other systems, a local key is commonly applied.  If conveying the original keys from the source or originating systems, see SourceSystemMemberKey and OriginatingSystemMemberKey.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Member"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "OriginatingSystemMemberKey": {
+    "definition": "The system key, a unique record identifier, from the Originating system.  The Originating system is the system with authoritative control over the record.  For example, the Multiple Listing Service where the member was input.  There may be cases where the Source System (how you received the record) is not the Originating System.  See Source System Key for more information. ",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Member"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "core"
   },
   "OriginatingSystemName": {
+    "definition": "The name of the Originating record provider.  Most commonly the name of the MLS. The place where the member is originally input by the member.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "bronze",
-    "path": "/Member"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "bronze"
   },
   "OriginatingSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Originating record provider.  The Originating system is the system with authoritative control over the record.  For example; the name of the MLS where the member was input.  In cases where the Originating system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/Member"
+    "synonyms": [
+      "MLSID"
+    ],
+    "level": "platinum"
   },
   "SourceSystemMemberKey": {
+    "definition": "The system key, a unique record identifier, from the Source System.  The Source System is the system from which the record was directly received.  In cases where the Source System was not where the record originated (the authoritative system), see the Originating System fields. ",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Member"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "silver"
   },
   "SourceSystemName": {
+    "definition": "The name of the immediate record provider.  The system from which the record was directly received.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Member"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "silver"
   },
   "SourceSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Source record provider.  The source system is the system from which the record was directly received.  In cases where the source system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/Member"
+    "synonyms": [
+      "MLSID"
+    ],
+    "level": "platinum"
   },
   "MemberMlsId": {
+    "definition": "The local, well-known identifier for the member. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberLoginId": {
+    "definition": "The ID used to logon to the MLS system.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Member"
+    "level": "bronze"
   },
   "MemberNationalAssociationId": {
+    "definition": "The national association ID of the member.  i.e. in the U.S. is the NRDS number.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberPassword": {
+    "definition": "A password that the member whishes to share with other systems.  Normal security considerations apply and are the responsibility of the entity utilizing this field.",
     "type": "string",
     "maxLength": 25,
-    "level": "silver",
-    "path": "/Member"
+    "level": "silver"
   },
   "MemberNamePrefix": {
+    "definition": "Prefix to the name (e.g. Dr. Mr. Ms. etc.)",
     "type": "string",
     "maxLength": 10,
-    "level": "bronze",
-    "path": "/Member"
+    "synonyms": [
+      "Salutation",
+      "Title"
+    ],
+    "level": "bronze"
   },
   "MemberFirstName": {
+    "definition": "The first name of the Member.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberMiddleName": {
+    "definition": "The middle name of the Member.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberLastName": {
+    "definition": "The last name of the Member.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberNameSuffix": {
+    "definition": "Suffix to the surname (e.g. Esq.,  Jr.,  III etc.)",
     "type": "string",
     "maxLength": 10,
-    "level": "bronze",
-    "path": "/Member"
+    "level": "bronze"
   },
   "MemberFullName": {
+    "definition": "The full name of the Member. (First Middle Last) or a alternate full name.",
     "type": "string",
     "maxLength": 150,
-    "level": "bronze",
-    "path": "/Member"
+    "level": "bronze"
   },
   "MemberNickname": {
+    "definition": "An alternate name used by the Member, usually as a substitute for the first name.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Member"
+    "level": "bronze"
   },
   "JobTitle": {
+    "definition": "The title or position of the member within their organization.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Member"
+    "level": "silver"
   },
   "MemberEmail": {
+    "definition": "The email address of the Member.",
     "type": "string",
     "maxLength": 80,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberPreferredPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberPreferredPhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberOfficePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberOfficePhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberMobilePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberDirectPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Member"
+    "level": "bronze"
   },
   "MemberHomePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Member"
+    "level": "bronze"
   },
   "MemberFax": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Member"
+    "level": "bronze"
   },
   "MemberPager": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "platinum",
-    "path": "/Member"
+    "level": "platinum"
   },
   "MemberVoiceMail": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Member"
+    "level": "bronze"
   },
   "MemberVoiceMailExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "bronze",
-    "path": "/Member"
+    "level": "bronze"
   },
   "MemberTollFreePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Member"
+    "level": "bronze"
   },
   "MemberPhoneTTYTDD": {
+    "definition": "(Telecommunications Device for the Deaf/TeleTYpewriter) A user terminal with keyboard input and printer or display output used by the hearing and speech impaired. The device contains a modem and is used over a standard analog phone line. If a recipient does not have a corresponding terminal device, TDD/TTY users dial a relay service composed of operators who receive the typed messages, call the recipients and speak the messages to them. The operators also type the responses back to the TDD/TTY user.",
     "type": "string",
     "maxLength": 16,
-    "level": "platinum",
-    "path": "/Member"
+    "level": "platinum"
   },
   "MemberOtherPhoneType": {
+    "definition": "The type of \"other\" phone.  i.e. Preferred, Office, Mobile, Direct, Home, Fax, Pager, Voicemail, Toll Free, SMS, 1, 2, 3, First, Second, Third, etc..  This is used as the list of options for the Member Other Phone repeating elements. ",
     "type": "string",
     "maxLength": 25,
     "level": "bronze",
-    "path": "/Member",
     "repeating": true
   },
   "MemberOtherPhones": [
@@ -216,24 +241,24 @@
         "type": "string"
       },
       "Number": {
+        "definition": "The \"other\" phone option allowing members to convey additional phone numbers other than those already covered by the MemberMobilePhone, MemberFax, etc., fields.  This is a repeating element.",
         "type": "string",
         "maxLength": 16,
-        "level": "bronze",
-        "path": "/Member"
+        "level": "bronze"
       },
       "Ext": {
+        "definition": "The \"other\" phone option allowing members to convey additional phone numbers other than those already covered by the MemberMobilePhone, MemberFax, etc., fields.  This is a repeating element.",
         "type": "string",
         "maxLength": 10,
-        "level": "bronze",
-        "path": "/Member"
+        "level": "bronze"
       }
     }
   ],
   "SocialMediaType": {
+    "definition": "A list of types of sites, blog, social media, the Member URL or ID is referring to.  i.e. Website, Blog, Facebook, Twitter, LinkedIn, Skype, etc.,  This list is used to populate the Type with repeating Social Media URL or ID types.",
     "type": "string",
     "maxLength": 25,
     "level": "bronze",
-    "path": "/Member",
     "repeating": true
   },
   "SocialMedias": [
@@ -242,48 +267,49 @@
         "type": "string"
       },
       "UrlOrId": {
+        "definition": "The website URL or ID of social media site or account of the member.  This is a repeating element.  Replace [Type] with any of the options from the SocialMediaType field to create a unique field for that type of social media.  For example: SocialMediaFacebookUrlOrID, SocialMediaSkypeUrlOrID, etc.",
         "type": "string",
         "maxLength": 8000,
-        "level": "bronze",
-        "path": "/Member"
+        "level": "bronze"
       }
     }
   ],
   "MemberAOR": {
+    "definition": "The Member's Primary Board or Association of REALTORS.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberAORMlsId": {
+    "definition": "The local, well-known identifier for the member's Association of REALTORS. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Member"
+    "level": "bronze"
   },
   "MemberAORkey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the MemberAORkey is the system unique identifier from the system that the record was retrieved. This may be identical to the related xxxId.",
     "type": "string",
     "maxLength": 255,
-    "level": "bronze",
-    "path": "/Member"
+    "level": "bronze"
   },
   "MemberAORkeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the MemberAORkey is the system unique identifier from the system that the record was retrieved. This may be identical to the related xxxId.  This is the numeric only key and used as an alternative to the MemberAORkey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Member"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "MemberStateLicense": {
+    "definition": "The license of the Member. Separate multiple licenses with a comma and space.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberStateLicenseState": {
+    "definition": "The state in which the member is licensed.",
     "type": "string",
     "maxLength": 2,
     "lookup": "StateOrProvince",
     "level": "bronze",
-    "path": "/Member",
     "enum": [
       "AK",
       "AL",
@@ -353,36 +379,37 @@
     ]
   },
   "MemberDesignation": {
+    "definition": "Designations and certifications acknowledging experience and expertise in various real estate sectors are awarded by NAR and each affiliated group upon completion of required courses.",
     "type": [
       "string"
     ],
-    "level": "silver",
-    "path": "/Member"
+    "maxLength": 50,
+    "level": "silver"
   },
   "MemberAddress1": {
+    "definition": "The street number, direction, name and suffix of the member.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberAddress2": {
+    "definition": "The unit/suite number of the member.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberCity": {
+    "definition": "The city of the member.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberStateOrProvince": {
+    "definition": "The state or province in which the member is addressed.",
     "type": "string",
     "maxLength": 2,
     "lookup": "StateOrProvince",
     "level": "core",
-    "path": "/Member",
     "enum": [
       "AK",
       "AL",
@@ -452,35 +479,42 @@
     ]
   },
   "MemberPostalCode": {
+    "definition": "The postal code of the member.",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberPostalCodePlus4": {
+    "definition": "The extension of the postal/zip code.  i.e. +4",
     "type": "string",
     "maxLength": 4,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "MemberCarrierRoute": {
+    "definition": "The group of addresses to which the USPS assigns the same code to aid in mail delivery. For the USPS, these codes are 9 digits: 5 numbers for the ZIP Code, one letter for the carrier route type, and 3 numbers for the carrier route number.",
     "type": "string",
     "maxLength": 9,
-    "level": "bronze",
-    "path": "/Member"
+    "synonyms": [
+      "RR",
+      "CR"
+    ],
+    "level": "bronze"
   },
   "MemberCountyOrParish": {
+    "definition": "The county or parish in which the member is addressed.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Member"
+    "synonyms": [
+      "County"
+    ],
+    "level": "core"
   },
   "MemberCountry": {
+    "definition": "The country abbreviation in a postal address.",
     "type": "string",
     "maxLength": 2,
     "lookup": "Country",
     "level": "core",
-    "path": "/Member",
     "enum": [
       "AF",
       "AL",
@@ -732,33 +766,33 @@
     ]
   },
   "MemberMlsAccessYN": {
+    "definition": "Does the member have access to the MLS system.",
     "type": "boolean",
-    "level": "silver",
-    "path": "/Member"
+    "level": "silver"
   },
   "MemberStatus": {
+    "definition": "Is the account active, inactive or under disciplinary action.",
     "type": "string",
     "maxLength": 25,
     "lookup": "MemberStatus",
     "level": "core",
-    "path": "/Member",
     "enum": [
       "Active",
       "Inactive"
     ]
   },
   "MemberMlsSecurityClass": {
+    "definition": "The MLS security group or class given to the member.  ",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Member"
+    "level": "bronze"
   },
   "MemberType": {
+    "definition": "The type of member.  i.e. Agent, Broker, Office Manager, Appraiser, Photographer, Assistants, MLO, Realtor, Association Staff, MLS Staff, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "MemberType",
     "level": "bronze",
-    "path": "/Member",
     "enum": [
       "Association Staff",
       "Designated REALTOR Appraiser",
@@ -775,24 +809,25 @@
     ]
   },
   "MemberIsAssistantTo": {
+    "definition": "The MemberMlsId of the Agent/Broker that this member is an assistant.  The typical use will be to add the agent's ID to this field when editing the member record of the assistant.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/Member"
+    "level": "platinum"
   },
   "MemberAssociationComments": {
+    "definition": "The association's notes regarding the member.",
     "type": "string",
     "maxLength": 500,
-    "level": "silver",
-    "path": "/Member"
+    "level": "silver"
   },
   "MemberLanguages": {
+    "definition": "The languages the member speaks.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "Languages",
     "level": "silver",
-    "path": "/Member",
     "enum": [
       "Abkhazian",
       "Afar",
@@ -987,48 +1022,53 @@
     ]
   },
   "SyndicateTo": {
+    "definition": "When permitted by the broker, the options made by the individual agent on where they would like their listings syndicated.  i.e. Zillow, Trulia, Homes.com, etc.",
     "type": [
       "string"
     ],
-    "level": "gold",
-    "path": "/Member"
+    "maxLength": 1024,
+    "level": "gold"
   },
   "OfficeName": {
+    "definition": "The legal name of the brokerage.",
     "type": "string",
     "maxLength": 255,
-    "level": "bronze",
-    "path": "/Member"
+    "level": "bronze"
   },
   "OfficeKey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set. This is a foreign key relating to the Office resource's OfficeKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "OfficeKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set. This is a foreign key relating to the Office resource's OfficeKey.  This is the numeric only key and used as an alternative to the MemberAORkey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Member"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "OfficeMlsId": {
+    "definition": "The local, well-known identifier. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "path": "/Member"
+    "level": "core"
   },
   "OriginalEntryTimestamp": {
+    "definition": "Date/time the roster (member or office) record was originally input into the source system.",
     "type": "date",
-    "level": "core",
-    "path": "/Member"
+    "maxLength": 27,
+    "level": "core"
   },
   "LastLoginTimestamp": {
+    "definition": "Date/time the member last logged into the source or other system.",
     "type": "date",
-    "level": "silver",
-    "path": "/Member"
+    "maxLength": 27,
+    "level": "silver"
   },
   "ModificationTimestamp": {
+    "definition": "Date/time the roster (member or office) record was last modified.",
     "type": "date",
-    "level": "core",
-    "path": "/Member"
+    "maxLength": 27,
+    "level": "core"
   }
 }

--- a/lib/office.json
+++ b/lib/office.json
@@ -1,94 +1,115 @@
 {
   "OfficeKey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set. ",
     "type": "string",
     "maxLength": 255,
     "level": "core",
-    "path": "/Office",
     "primary": true
   },
   "OfficeKeyNumeric": {
+    "definition": "A unique identifier for this record from the immediate source. This is the numeric only key and used as an alternative to the OfficeKey fields.  This is the local key of the system.  When records are received from other systems, a local key is commonly applied.  If conveying the original keys from the source or originating systems, see SourceSystemOfficeKey and OriginatingSystemOfficeKey.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Office"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "OriginatingSystemOfficeKey": {
+    "definition": "The system key, a unique record identifier, from the Originating system.  The Originating system is the system with authoritative control over the record.  For example, the Multiple Listing Service where the office was input.  There may be cases where the Source System (how you received the record) is not the Originating System.  See Source System Key for more information. ",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Office"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "core"
   },
   "OriginatingSystemName": {
+    "definition": "The name of the Originating record provider.  Most commonly the name of the MLS. The place where the office is originally input by the member.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "bronze",
-    "path": "/Office"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "bronze"
   },
   "OriginatingSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Originating record provider.  The Originating system is the system with authoritative control over the record.  For example; the name of the MLS where the office was input.  In cases where the Originating system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/Office"
+    "synonyms": [
+      "MLSID"
+    ],
+    "level": "platinum"
   },
   "SourceSystemOfficeKey": {
+    "definition": "The system key, a unique record identifier, from the Source System.  The Source System is the system from which the record was directly received.  In cases where the Source System was not where the record originated (the authoritative system), see the Originating System fields. ",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Office"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "silver"
   },
   "SourceSystemName": {
+    "definition": "The name of the immediate record provider.  The system from which the record was directly received.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Office"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "silver"
   },
   "SourceSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Source record provider.  The source system is the system from which the record was directly received.  In cases where the source system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/Office"
+    "synonyms": [
+      "MLSID"
+    ],
+    "level": "platinum"
   },
   "OfficeMlsId": {
+    "definition": "The local, well-known identifier. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "path": "/Office"
+    "level": "core"
   },
   "OfficeName": {
+    "definition": "The legal name of the brokerage.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Office"
+    "level": "core"
   },
   "OfficePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Office"
+    "level": "core"
   },
   "OfficePhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Office"
+    "level": "core"
   },
   "OfficeFax": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Office"
+    "level": "bronze"
   },
   "OfficeEmail": {
+    "definition": "The email address of the office",
     "type": "string",
     "maxLength": 80,
-    "level": "core",
-    "path": "/Office"
+    "level": "core"
   },
   "OfficeType": {
+    "definition": "The type of business conducted by the office.  i.e. Real Estate, Appraiser, etc.",
     "type": "string",
     "maxLength": 50,
     "lookup": "OfficeType",
     "level": "bronze",
-    "path": "/Office",
     "enum": [
       "Affiliate",
       "Appraiser",
@@ -104,16 +125,16 @@
     ]
   },
   "OfficeBranchType": {
+    "definition": "The level of the office in the hierarchy of Main, Branch, Stand Alone, etc.,",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Office"
+    "level": "silver"
   },
   "SocialMediaType": {
+    "definition": "A list of types of sites, blog, social media, the Office URL or ID is referring to.  i.e. Website, Blog, Facebook, Twitter, LinkedIn, Skype, etc.,  This list is used to populate the Type with repeating Social Media URL or ID types.",
     "type": "string",
     "maxLength": 25,
     "level": "silver",
-    "path": "/Office",
     "repeating": true
   },
   "SocialMedias": [
@@ -122,106 +143,109 @@
         "type": "string"
       },
       "UrlOrId": {
+        "definition": "The website URL or ID of social media site or account of the Office.  This is a repeating element.  Replace [Type] with any of the options from the SocialMediaType field to create a unique field for that type of social media.  For example: SocialMediaFacebookUrlOrID, SocialMediaSkypeUrlOrID, etc.",
         "type": "string",
         "maxLength": 8000,
-        "level": "silver",
-        "path": "/Office"
+        "level": "silver"
       }
     }
   ],
   "OfficeAOR": {
+    "definition": "The Office's Board or Association of REALTORS.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Office"
+    "level": "bronze"
   },
   "OfficeAORMlsId": {
+    "definition": "The local, well-known identifier for the office's Association of REALTORS. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Office"
+    "level": "bronze"
   },
   "OfficeAORkey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the OfficeAORkey is the system unique identifier from the system that the record was retrieved. This may be identical to the related xxxId.  This is a foreign key relating to the AOR's member management system in which the record was originated.",
     "type": "string",
     "maxLength": 255,
-    "level": "bronze",
-    "path": "/Office"
+    "level": "bronze"
   },
   "OfficeAORkeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the OfficeAORkey is the system unique identifier from the system that the record was retrieved. This may be identical to the related xxxId.  This is a foreign key relating to the AOR's member management system in which the record was originated.  This is the numeric only key and used as an alternative to the OfficeAORkey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Office"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "OfficeNationalAssociationId": {
+    "definition": "The national association ID of the office.  i.e. in the U.S. is the NRDS number.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "path": "/Office"
+    "level": "core"
   },
   "OfficeCorporateLicense": {
+    "definition": "When an office/firm is a corporation, an independent license number is issued.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Office"
+    "level": "bronze"
   },
   "OfficeBrokerMlsId": {
+    "definition": "The MemberMlsId of the responsible/owning broker.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "path": "/Office"
+    "level": "core"
   },
   "OfficeBrokerKey": {
+    "definition": "The MemberKey of the responsible/owning broker.  This is a foreign key relating to the Member resource's MemberKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Office"
+    "level": "core"
   },
   "OfficeBrokerKeyNumeric": {
+    "definition": "The MemberKey of the responsible/owning broker.  This is a foreign key relating to the Member resource's MemberKey.  This is the numeric only key and used as an alternative to the OfficeBrokerKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Office"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "OfficeManagerMlsId": {
+    "definition": "The lead Office Manager for the given office.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Office"
+    "level": "bronze"
   },
   "OfficeManagerKey": {
+    "definition": "The lead Office Manager for the given office.  This is a foreign key relating to the Member resource's MemberKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "bronze",
-    "path": "/Office"
+    "level": "bronze"
   },
   "OfficeManagerKeyNumeric": {
+    "definition": "The lead Office Manager for the given office.  This is a foreign key relating to the Member resource's MemberKey.  This is the numeric only key and used as an alternative to the OfficeManagerKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Office"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "OfficeAddress1": {
+    "definition": "The street number, direction, name and suffix of the office.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Office"
+    "level": "core"
   },
   "OfficeAddress2": {
+    "definition": "The unit/suite number of the office.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Office"
+    "level": "core"
   },
   "OfficeCity": {
+    "definition": "The city of the office.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Office"
+    "level": "core"
   },
   "OfficeStateOrProvince": {
+    "definition": "The state or province in which the office is located.",
     "type": "string",
     "maxLength": 2,
     "lookup": "StateOrProvince",
     "level": "core",
-    "path": "/Office",
     "enum": [
       "AK",
       "AL",
@@ -291,89 +315,96 @@
     ]
   },
   "OfficePostalCode": {
+    "definition": "The postal code of the office.",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Office"
+    "level": "core"
   },
   "OfficePostalCodePlus4": {
+    "definition": "The extension of the postal/zip code.  i.e. +4",
     "type": "string",
     "maxLength": 4,
-    "level": "core",
-    "path": "/Office"
+    "level": "core"
   },
   "OfficeCountyOrParish": {
+    "definition": "The county or parish in which the offices is located.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Office"
+    "synonyms": [
+      "County"
+    ],
+    "level": "core"
   },
   "OfficeStatus": {
+    "definition": "Is the office active, inactive or under disciplinary action.",
     "type": "string",
     "maxLength": 25,
     "lookup": "OfficeStatus",
     "level": "core",
-    "path": "/Office",
     "enum": [
       "Active",
       "Inactive"
     ]
   },
   "OfficeAssociationComments": {
+    "definition": "Notes relating to the office.",
     "type": "string",
     "maxLength": 500,
-    "level": "silver",
-    "path": "/Office"
+    "level": "silver"
   },
   "OriginalEntryTimestamp": {
+    "definition": "Date/time the roster (member or office) record was originally input into the source system.",
     "type": "date",
-    "level": "core",
-    "path": "/Office"
+    "maxLength": 27,
+    "level": "core"
   },
   "ModificationTimestamp": {
+    "definition": "Date/time the roster (member or office) record was last modified.",
     "type": "date",
-    "level": "core",
-    "path": "/Office"
+    "maxLength": 27,
+    "level": "core"
   },
   "MainOfficeKey": {
+    "definition": "OfficeKey of the Main Office in a firm/company of offices.  This is a self referencing foreign key relating to this resource's OfficeKey.  This key may be the same value as the OfficeKey for a given record if the given office is the Main Office.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Office"
+    "level": "core"
   },
   "MainOfficeKeyNumeric": {
+    "definition": "OfficeKey of the Main Office in a firm/company of offices.  This is a self referencing foreign key relating to this resource's OfficeKey.  This key may be the same value as the OfficeKey for a given record if the given office is the Main Office.  This is the numeric only key and used as an alternative to the MainOfficeKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Office"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "MainOfficeMlsId": {
+    "definition": "OfficeMlsId of the Main Office in a firm/company of offices.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "path": "/Office"
+    "level": "core"
   },
   "FranchiseAffiliation": {
+    "definition": "The name of the franchise to which the broker/office is contracted.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Office"
+    "level": "silver"
   },
   "IDXOfficeParticipationYN": {
+    "definition": "Does the Office/Broker participate in IDX.",
     "type": "boolean",
-    "level": "bronze",
-    "path": "/Office"
+    "level": "bronze"
   },
   "SyndicateTo": {
+    "definition": "The principal broker's choice on where they would like their listings syndicated.  i.e. Zillow, Trulia, Homes.com, etc.",
     "type": [
       "string"
     ],
-    "level": "gold",
-    "path": "/Office"
+    "maxLength": 1024,
+    "level": "gold"
   },
   "SyndicateAgentOption": {
+    "definition": "A list of options allowing the broker to pass the decision of syndication choice down to the listing agents.  i.e. No Agent Choice, Allow Agent Choice, Restrict Agent Choice, etc.",
     "type": "string",
     "maxLength": 50,
-    "level": "gold",
-    "path": "/Office"
+    "level": "gold"
   }
 }

--- a/lib/openhouse.json
+++ b/lib/openhouse.json
@@ -1,135 +1,187 @@
 {
   "OpenHouseKey": {
+    "definition": "A unique identifier for this record from the immediate source. This may be a number, or string that can include URI or other forms.  This is the system you are connecting to and not necessarily the original source of the record.",
     "type": "string",
     "maxLength": 255,
     "level": "core",
-    "path": "/OpenHouse",
     "primary": true
   },
   "OpenHouseKeyNumeric": {
+    "definition": "A unique identifier for this record from the immediate source. This may be a number, or string that can include URI or other forms.  This is the system you are connecting to and not necessarily the original source of the record.  This is the numeric only key and used as an alternative to the OpenHouseKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/OpenHouse"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "OpenHouseId": {
+    "definition": "The well known identifier for the listing. The value may be identical to that of the Listing Key, but the Listing ID is intended to be the value used by a human to retrieve the information about a specific listing. In a multiple originating system or a merged system, this value may not be unique and may require the use of the provider system to create a synthetic unique value.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/OpenHouse"
+    "level": "core"
   },
   "OriginatingSystemKey": {
+    "definition": "The system key, a unique record identifier, from the Originating system.  The Originating system is the system with authoritative control over the record.  For example, the Multiple Listing Service where the Open House was input.  There may be cases where the Source System (how you received the record) is not the Originating System.  See Source System Key for more information. ",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/OpenHouse"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "core"
   },
   "OriginatingSystemName": {
+    "definition": "The name of the Originating record provider.  Most commonly the name of the MLS. The place where the Open House is originally input.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "bronze",
-    "path": "/OpenHouse"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "bronze"
   },
   "OriginatingSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Originating record provider.  The Originating system is the system with authoritative control over the record.  For example; the name of the MLS where the Open House was input.  In cases where the Originating system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/OpenHouse"
+    "level": "platinum"
   },
   "SourceSystemKey": {
+    "definition": "The system key, a unique record identifier, from the Source System.  The Source System is the system from which the record was directly received.  In cases where the Source System was not where the record originated (the authoritative system), see the Originating System fields. ",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/OpenHouse"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "silver"
   },
   "SourceSystemName": {
+    "definition": "The name of the Open House record provider.  The system from which the record was directly received.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/OpenHouse"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "silver"
   },
   "SourceSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Source record provider.  The source system is the system from which the record was directly received.  In cases where the source system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/OpenHouse"
+    "synonyms": [
+      "MLSID"
+    ],
+    "level": "platinum"
   },
   "ListingKey": {
+    "definition": "A unique identifier for the listing record related to this Open House. This may be a number, or string that can include URI or other forms.  This is the system you are connecting to and not necessarily the original source of the record.   This may be a foreign key from the resource selected in the ResourceName field.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/OpenHouse"
+    "synonyms": [
+      "SystemUniqueID",
+      "ImmediateSourceID"
+    ],
+    "level": "core"
   },
   "ListingKeyNumeric": {
+    "definition": "A unique identifier for the listing record related to this Open House. This may be a number, or string that can include URI or other forms.  This is the system you are connecting to and not necessarily the original source of the record.   This may be a foreign key from the resource selected in the ResourceName field.  This is the numeric only key and used as an alternative to the ListingKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/OpenHouse"
+    "maxLength": 255,
+    "synonyms": [
+      "SystemUniqueID",
+      "ImmediateSourceID"
+    ],
+    "level": "platinum"
   },
   "ListingId": {
+    "definition": "The well known identifier for the listing related to this Open House. The value may be identical to that of the Listing Key, but the Listing ID is intended to be the value used by a human to retrieve the information about a specific listing. In a multiple originating system or a merged system, this value may not be unique and may require the use of the provider system to create a synthetic unique value.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/OpenHouse"
+    "synonyms": [
+      "MLNumber",
+      "MLSNumber",
+      "ListingNumber"
+    ],
+    "level": "core"
   },
   "ModificationTimestamp": {
+    "definition": "The transactional timestamp automatically recorded by the MLS system representing the date/time the Open House was last modified.",
     "type": "date",
-    "level": "core",
-    "path": "/OpenHouse"
+    "maxLength": 27,
+    "synonyms": [
+      "ModificationDateTime",
+      "DateTimeModified",
+      "ModDate",
+      "DateMod",
+      "UpdateDate",
+      "UpdateTimestamp"
+    ],
+    "level": "core"
   },
   "OriginalEntryTimestamp": {
+    "definition": "The transactional timestamp automatically recorded by the MLS system representing the date/time the Open House was entered and made visible to members of the MLS.",
     "type": "date",
-    "level": "bronze",
-    "path": "/OpenHouse"
+    "maxLength": 27,
+    "synonyms": [
+      "EntryDate",
+      "InputDate",
+      "DateTimeCreated",
+      "CreatedDate."
+    ],
+    "level": "bronze"
   },
   "OpenHouseDate": {
+    "definition": "The date on which the open house will occur.",
     "type": "date",
-    "level": "core",
-    "path": "/OpenHouse"
+    "maxLength": 24,
+    "level": "core"
   },
   "OpenHouseStartTime": {
+    "definition": "The time the open house begins.",
     "type": "date",
-    "level": "core",
-    "path": "/OpenHouse"
+    "maxLength": 27,
+    "level": "core"
   },
   "OpenHouseEndTime": {
+    "definition": "The time the open house ends.",
     "type": "date",
-    "level": "core",
-    "path": "/OpenHouse"
+    "maxLength": 27,
+    "level": "core"
   },
   "ShowingAgentMlsID": {
+    "definition": "The local, well-known identifier for the member. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "path": "/OpenHouse"
+    "level": "core"
   },
   "ShowingAgentKey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the ListAgentKey is the system unique identifier from the system that the record was retrieved. This may be identical to the related xxxId.  This is a foreign key relating to the Member resource's MemberKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/OpenHouse"
+    "level": "core"
   },
   "ShowingAgentKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the ListAgentKey is the system unique identifier from the system that the record was retrieved. This may be identical to the related xxxId.  This is a foreign key relating to the Member resource's MemberKey.  This is the numeric only key and used as an alternative to the ShowingAgentKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/OpenHouse"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "ShowingAgentFirstName": {
+    "definition": "The first name of the showing agent.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/OpenHouse"
+    "level": "core"
   },
   "ShowingAgentLastName": {
+    "definition": "The last name of the showing agent.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/OpenHouse"
+    "level": "core"
   },
   "OpenHouseType": {
+    "definition": "The type of open house.  i.e. Public, Broker, Office, Association, Private (invitation or targeted publication).",
     "type": "string",
     "maxLength": 25,
     "lookup": "OpenHouseType",
     "level": "core",
-    "path": "/OpenHouse",
     "enum": [
       "Public",
       "Broker",
@@ -137,22 +189,22 @@
     ]
   },
   "AppointmentRequiredYN": {
+    "definition": "Indicates whether or not the OpenHouse requires an appointment.",
     "type": "boolean",
-    "level": "bronze",
-    "path": "/OpenHouse"
+    "level": "bronze"
   },
   "Refreshments": {
+    "definition": "A description of the refreshments that will be served at the open house.",
     "type": "string",
     "maxLength": 255,
-    "level": "bronze",
-    "path": "/OpenHouse"
+    "level": "bronze"
   },
   "OpenHouseAttendedBy": {
+    "definition": "Will the open house be attended by a licensed agent?  Options are attended by agent, attended by the seller or unattended.",
     "type": "string",
     "maxLength": 25,
     "lookup": "Attended",
     "level": "bronze",
-    "path": "/OpenHouse",
     "enum": [
       "Agent",
       "Seller",
@@ -160,17 +212,17 @@
     ]
   },
   "OpenHouseRemarks": {
+    "definition": "Comments, instructions or information about the open house.",
     "type": "string",
     "maxLength": 500,
-    "level": "core",
-    "path": "/OpenHouse"
+    "level": "core"
   },
   "OpenHouseStatus": {
+    "definition": "Status of the open house, i.e. Active, Cancelled, Ended.",
     "type": "string",
     "maxLength": 25,
     "lookup": "OpenHouseStatus",
     "level": "core",
-    "path": "/OpenHouse",
     "enum": [
       "Active",
       "Canceled",

--- a/lib/ouid.json
+++ b/lib/ouid.json
@@ -1,70 +1,71 @@
 {
   "OrganizationUniqueIdKey": {
+    "definition": "The key field used by the system hosting a table of OUIDs.  This key is likely to be unique to each hosting system and is not meant to be a universal ID for an organization, but rather a key used by clients of the hosting system.  The actual OUID is the Organization Unique ID field.",
     "type": "string",
     "maxLength": 255,
     "level": "platinum",
-    "path": "/OUID",
     "primary": true
   },
   "OrganizationUniqueIdKeyNumeric": {
+    "definition": "The key field used by the system hosting a table of OUIDs.  This key is likely to be unique to each hosting system and is not meant to be a universal ID for an organization, but rather a key used by clients of the hosting system.  The actual OUID is the Organization Unique ID field.  This is the numeric only key and used as an alternative to the OrganizationUniqueIdKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/OUID"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "OrganizationUniqueId": {
+    "definition": "The OUID.  This is the unique ID assigned to organizations included in the OUID resource.  Assignment of OUIDs will be centralized and may not be created by systems hosting the OUID resource.  Contact info@RESO.org for information on obtaining an OUID.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationMlsCode": {
+    "definition": "If the organization is an MLS it is likely they already have an ID or code based on their name or an abbreviation.  This field supports the continued use/reference to that legacy code.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationMlsVendorName": {
+    "definition": "If the organization uses an MLS system, this is the textual name of the vendor.",
     "type": "string",
     "maxLength": 255,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationMlsVendorOuid": {
+    "definition": "If the organization uses an MLS system, this is that vendor's OUID.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationName": {
+    "definition": "The textual name of the organization represented by a given OUID record.",
     "type": "string",
     "maxLength": 255,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationAddress1": {
+    "definition": "The street number, direction, name and suffix of the organization.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationAddress2": {
+    "definition": "The unit/suite number of the organization.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationCity": {
+    "definition": "The city of the organization.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationStateOrProvince": {
+    "definition": "The state or province in which the organization is addressed.",
     "type": "string",
     "maxLength": 2,
     "lookup": "StateOrProvince",
     "level": "platinum",
-    "path": "/OUID",
     "enum": [
       "AK",
       "AL",
@@ -134,35 +135,42 @@
     ]
   },
   "OrganizationPostalCode": {
+    "definition": "The postal code of the organization.",
     "type": "string",
     "maxLength": 10,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationPostalCodePlus4": {
+    "definition": "The extension of the postal/zip code.  i.e. +4",
     "type": "string",
     "maxLength": 4,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationCarrierRoute": {
+    "definition": "The group of addresses to which the USPS assigns the same code to aid in mail delivery. For the USPS, these codes are 9 digits: 5 numbers for the ZIP Code, one letter for the carrier route type, and 3 numbers for the carrier route number.",
     "type": "string",
     "maxLength": 9,
-    "level": "platinum",
-    "path": "/OUID"
+    "synonyms": [
+      "RR",
+      "CR"
+    ],
+    "level": "platinum"
   },
   "OrganizationCountyOrParish": {
+    "definition": "The county or parish in which the organization is addressed.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/OUID"
+    "synonyms": [
+      "County"
+    ],
+    "level": "platinum"
   },
   "OrganizationCountry": {
+    "definition": "The country abbreviation in a postal address.",
     "type": "string",
     "maxLength": 2,
     "lookup": "Country",
     "level": "platinum",
-    "path": "/OUID",
     "enum": [
       "AF",
       "AL",
@@ -414,82 +422,86 @@
     ]
   },
   "OrganizationType": {
+    "definition": "The type of organization.  i.e. MLS, Vendor, Association, etc.  This is not a substitute or alternative for the Office resource, however it may be that a brokerage has a record in this table for a non-listing purpose.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationContactNamePrefix": {
+    "definition": "Prefix to the name of the Organization Contact. (e.g. Dr. Mr. Ms. etc.)",
     "type": "string",
     "maxLength": 10,
-    "level": "platinum",
-    "path": "/OUID"
+    "synonyms": [
+      "Salutation",
+      "Title"
+    ],
+    "level": "platinum"
   },
   "OrganizationContactFirstName": {
+    "definition": "The first name of the Organization Contact.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationContactMiddleName": {
+    "definition": "The middle name of the Organization Contact.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationContactLastName": {
+    "definition": "The last name of the Organization Contact.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationContactNameSuffix": {
+    "definition": "Suffix to the surname (e.g. Esq.,  Jr.,  III etc.) of the Organization Contact.",
     "type": "string",
     "maxLength": 10,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationContactFullName": {
+    "definition": "The full name of the Organization Contact. (First Middle Last) or a alternate full name.",
     "type": "string",
     "maxLength": 150,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationContactJobTitle": {
+    "definition": "The title or position of the Organization Contact.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationContactEmail": {
+    "definition": "The email address of the Organization Contact.",
     "type": "string",
     "maxLength": 80,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationContactPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationContactPhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationContactFax": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationSocialMediaType": {
+    "definition": "A list of types of sites, blog, social media, the Organization URL or ID is referring to.  i.e. Website, Blog, Facebook, Twitter, LinkedIn, Skype, etc.,  This list is used to populate the Type with repeating Social Media URL or ID types.",
     "type": "string",
     "maxLength": 25,
     "level": "platinum",
-    "path": "/OUID",
     "repeating": true
   },
   "OrganizationSocialMedias": [
@@ -498,54 +510,55 @@
         "type": "string"
       },
       "UrlOrId": {
+        "definition": "The website URL or ID of social media site or account of the member.  This is a repeating element.  Replace [Type] with any of the options from the SocialMediaType field to create a unique field for that type of social media.  For example: SocialMediaFacebookUrlOrID, SocialMediaSkypeUrlOrID, etc.",
         "type": "string",
         "maxLength": 8000,
-        "level": "platinum",
-        "path": "/OUID"
+        "level": "platinum"
       }
     }
   ],
   "OrganizationAOR": {
+    "definition": "The Organization's Primary Board or Association of REALTORS if applicable.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationAorOuid": {
+    "definition": "The OUID for the Organization's Association of REALTORS if applicable.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationAorOuidKey": {
+    "definition": "The OrganizationUniqueIdKey of the AOR from the system serving the OUID resource.",
     "type": "string",
     "maxLength": 255,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationAorOuidKeyNumeric": {
+    "definition": "The OrganizationUniqueIdKey of the AOR from the system serving the OUID resource.  This is the numeric only key and used as an alternative to the OrganizationAorOuidKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/OUID"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "OrganizationNationalAssociationId": {
+    "definition": "The national association ID of the Organization if applicable.  i.e. in the U.S. is the NRDS number.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationStateLicense": {
+    "definition": "The license of the Organization if applicable. Separate multiple licenses with a comma and space.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OrganizationStateLicenseState": {
+    "definition": "The state in which the Organization is licensed if applicable.",
     "type": "string",
     "maxLength": 2,
     "lookup": "StateOrProvince",
     "level": "platinum",
-    "path": "/OUID",
     "enum": [
       "AK",
       "AL",
@@ -615,51 +628,57 @@
     ]
   },
   "OrganizationStatus": {
+    "definition": "Is the Organization active or inactive.  1 or true is active, 0 or false is inactive.  This field is not nullable.",
     "type": "boolean",
-    "level": "platinum",
-    "path": "/OUID"
+    "maxLength": 1,
+    "level": "platinum"
   },
   "OrganizationStatusChangeTimestamp": {
+    "definition": "The date/time of when the Organization Status was last changed.",
     "type": "date",
-    "level": "platinum",
-    "path": "/OUID"
+    "maxLength": 27,
+    "level": "platinum"
   },
   "OrganizationMemberCount": {
+    "definition": "The total number of active members in the Organization if applicable.",
     "type": "number",
-    "level": "platinum",
-    "path": "/OUID"
+    "maxLength": 14,
+    "level": "platinum"
   },
   "ChangedByMemberID": {
+    "definition": "The local, well-know identifier of the member (user) who made the change.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "ChangedByMemberKey": {
+    "definition": "The unique identifier of the member (user) who made the change.  This is a foreign key relating to the Member resource's MemberKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "ChangedByMemberKeyNumeric": {
+    "definition": "The unique identifier of the member (user) who made the change.  This is a foreign key relating to the Member resource's MemberKey.  This is the numeric only key and used as an alternative to the ChangedByMemberKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/OUID"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "OrganizationComments": {
+    "definition": "Comments or notes about the Organization.",
     "type": "string",
     "maxLength": 500,
-    "level": "platinum",
-    "path": "/OUID"
+    "level": "platinum"
   },
   "OriginalEntryTimestamp": {
+    "definition": "Date/time the Organization record was originally input into the source system.",
     "type": "date",
-    "level": "platinum",
-    "path": "/OUID"
+    "maxLength": 27,
+    "level": "platinum"
   },
   "ModificationTimestamp": {
+    "definition": "Date/time the Organization record was last modified.",
     "type": "date",
-    "level": "platinum",
-    "path": "/OUID"
+    "maxLength": 27,
+    "level": "platinum"
   }
 }

--- a/lib/property.json
+++ b/lib/property.json
@@ -1,77 +1,111 @@
 {
   "ListingKey": {
+    "definition": "A unique identifier for this record from the immediate source. This is a string that can include URI or other forms.  Alternatively use the ListingKeyNumeric for a numeric only key field.  This is the local key of the system.  When records are received from other systems, a local key is commonly applied.  If conveying the original keys from the source or originating systems, see SourceSystemKey and OriginatingSystemKey.",
     "type": "string",
     "maxLength": 255,
+    "synonyms": [
+      "SystemUniqueID",
+      "ImmediateSourceID"
+    ],
     "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing",
     "primary": true
   },
   "ListingKeyNumeric": {
+    "definition": "A unique identifier for this record from the immediate source. This is the numeric only key and used as an alternative to the ListingKey fields.  This is the local key of the system.  When records are received from other systems, a local key is commonly applied.  If conveying the original keys from the source or originating systems, see SourceSystemKey and OriginatingSystemKey.",
     "type": "number",
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "maxLength": 255,
+    "synonyms": [
+      "SystemUniqueID",
+      "ImmediateSourceID"
+    ],
+    "level": "platinum"
   },
   "ListingId": {
+    "definition": "The well known identifier for the listing. The value may be identical to that of the Listing Key, but the Listing ID is intended to be the value used by a human to retrieve the information about a specific listing. In a multiple originating system or a merged system, this value may not be unique and may require the use of the provider system to create a synthetic unique value.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "MLNumber",
+      "MLSNumber",
+      "ListingNumber"
+    ],
+    "level": "core"
   },
   "ListAOR": {
+    "definition": "The responsible Board or Association of REALTORS for this listing.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "ListingBoard",
+      "ListingAssociation"
+    ],
+    "level": "bronze"
   },
   "OriginatingSystemKey": {
+    "definition": "The system key, a unique record identifier, from the Originating system.  The Originating system is the system with authoritative control over the record.  For example, the Multiple Listing Service where the listing was input.  There may be cases where the Source System (how you received the record) is not the Originating System.  See Source System Key for more information. ",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "ProviderKey",
+      "AuthoritativeSystemKey"
+    ],
+    "level": "core"
   },
   "OriginatingSystemName": {
+    "definition": "The name of the Originating record provider.  Most commonly the name of the MLS. The place where the listing is originally input by the member.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "ProviderName",
+      "MLSID",
+      "AuthoritativeSystem"
+    ],
+    "level": "core"
   },
   "OriginatingSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Originating record provider.  The Originating system is the system with authoritative control over the record.  For example; the name of the MLS where the listing was input.  In cases where the Originating system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "AuthoritativeSystemID"
+    ],
+    "level": "platinum"
   },
   "SourceSystemKey": {
+    "definition": "The system key, a unique record identifier, from the Source System.  The Source System is the system from which the record was directly received.  In cases where the Source System was not where the record originated (the authoritative system), see the Originating System fields. ",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "core"
   },
   "SourceSystemName": {
+    "definition": "The name of the immediate record provider.  The system from which the record was directly received.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "core"
   },
   "SourceSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Source record provider.  The source system is the system from which the record was directly received.  In cases where the source system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/Property/Listing"
+    "level": "platinum"
   },
   "ListingService": {
+    "definition": "Defines the type or level of service the listing member will be providing to the selling home owner.  This will typically be a single selection.  Examples include Full Service, Limited Service or Entry Only.",
     "type": "string",
     "maxLength": 25,
+    "synonyms": [
+      "ServiceType",
+      "ServiceLevel"
+    ],
     "lookup": "ListingService",
     "level": "core",
-    "path": "/Property/Listing",
     "enum": [
       "Full Service",
       "Limited Service",
@@ -79,11 +113,14 @@
     ]
   },
   "ListingAgreement": {
+    "definition": "The nature of the agreement between the seller and the listing agent.  Examples are Exclusive Agency, Open Listing, etc.",
     "type": "string",
     "maxLength": 25,
+    "synonyms": [
+      "AgreementType"
+    ],
     "lookup": "ListingAgreement",
     "level": "core",
-    "path": "/Property/Listing",
     "enum": [
       "Exclusive Right To Lease",
       "Exclusive Agency",
@@ -95,36 +132,47 @@
     ]
   },
   "LeaseConsideredYN": {
+    "definition": "Will the seller consider leasing the property instead of selling?  Single select.",
     "type": "boolean",
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "IsLeaseConsidered",
+      "LeaseConsidered"
+    ],
+    "level": "bronze"
   },
   "HomeWarrantyYN": {
+    "definition": "Is a home warranty included in the sale of the property?  Single select.",
     "type": "boolean",
-    "level": "silver",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "HomeWarranty"
+    ],
+    "level": "silver"
   },
   "CopyrightNotice": {
+    "definition": "Notice of the legal rights of the owner of the information or data.",
     "type": "string",
     "maxLength": 500,
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "Copyright"
+    ],
+    "level": "bronze"
   },
   "Disclaimer": {
+    "definition": "Text that serves as the negation or limitation of the rights under a warranty given by a seller to a buyer.",
     "type": "string",
     "maxLength": 500,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "StandardStatus": {
+    "definition": "The status of the listing as it reflects the state of the contract between the listing agent and seller or an agreement with a buyer. (Active, Backup, Canceled, Closed, Expired, Pending, Withdrawn).  Single Select",
     "type": "string",
     "maxLength": 25,
+    "synonyms": [
+      "NormalizedListingStatus",
+      "RetsStatus"
+    ],
     "lookup": "StandardStatus",
     "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing",
     "enum": [
       "Active",
       "Active Under Contract",
@@ -140,100 +188,166 @@
     ]
   },
   "MlsStatus": {
+    "definition": "Local or regional status that are well known by business users. Each MlsStatus must map to a single StandardStatus. Multiple MlsStatus may map to a single StandardStatus.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "ListingStatus",
+      "Status"
+    ],
+    "level": "core"
   },
   "ApprovalStatus": {
+    "definition": "When an MLS has the ability to set a listing to Draft and/or has facility to allow an agent to input, but their manager to approve the listings before publishing, this field is used for such control.",
     "type": "string",
     "maxLength": 25,
-    "level": "silver",
-    "path": "/Property/Listing"
+    "level": "silver"
   },
   "ListingContractDate": {
+    "definition": "The effective date of the agreement between the seller and the seller's broker. This is the date entered by the agent reflecting when the change occurred contractually, not a timestamp of when the change was made in the MLS.",
     "type": "date",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "maxLength": 10,
+    "synonyms": [
+      "ListingDate",
+      "DateOfListing",
+      "ListDate",
+      "ListingContractDate",
+      "AgreementDate"
+    ],
+    "level": "core"
   },
   "ContractStatusChangeDate": {
+    "definition": "The date of the listings contractual status change. This is not necessarily the time the agent made the change in the MLS system, but rather the date of the contractual change.",
     "type": "date",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "maxLength": 10,
+    "synonyms": [
+      "StatusDate",
+      "StatusChange"
+    ],
+    "level": "core"
   },
   "ExpirationDate": {
+    "definition": "The date when the listing agreement will expire.  This is the date entered by the agent reflecting when the change occurred, or will occur, contractually, not a timestamp of when the change was made in the MLS.  The expiration date of listings, prior to their expiration, cancellation, sale or lease, is confidential information and should be restricted to the agent and their managers, partners or broker.",
     "type": "date",
-    "level": "core",
-    "path": "/Property/Listing"
+    "maxLength": 10,
+    "synonyms": [
+      "ExpirationDate",
+      "DateExpired",
+      "Expired"
+    ],
+    "level": "core"
   },
   "CancelationDate": {
+    "definition": "Date the listing contract between the seller and listing agent was cancelled.  This is the date entered by the agent reflecting when the change occurred contractually, not a timestamp of when the change was made in the MLS.",
     "type": "date",
-    "level": "core",
-    "path": "/Property/Listing"
+    "maxLength": 10,
+    "level": "core"
   },
   "ContingentDate": {
+    "definition": "The date an offer was made with a contingency. The Listing remains On Market.  This is the date entered by the agent reflecting when the change occurred contractually, not a timestamp of when the change was made in the MLS.",
     "type": "date",
-    "level": "core",
-    "path": "/Property/Listing"
+    "maxLength": 10,
+    "level": "core"
   },
   "WithdrawnDate": {
+    "definition": "Date the listing was withdrawn from the market.  This is not when a listing contact was cancelled or closed, but a withdrawal from the market while the contract between the seller and listing agent is still in effect and an offer has not been accepted. This is the date entered by the agent reflecting when the change occurred contractually, not a timestamp of when the change was made in the MLS.",
     "type": "date",
-    "level": "core",
-    "path": "/Property/Listing"
+    "maxLength": 10,
+    "level": "core"
   },
   "PurchaseContractDate": {
+    "definition": "With for-sale listings, the date an offer was accepted and the listing was no longer on market.  This is the date entered by the agent reflecting when the change occurred contractually, not a timestamp of when the change was made in the MLS.  With lease listings this may represent a meeting of the minds to lease, but some contractual requirements are yet to be fulfilled, such as contract signing or receipt of the deposit.",
     "type": "date",
-    "level": "core",
-    "path": "/Property/Listing"
+    "maxLength": 10,
+    "synonyms": [
+      "PendingDate",
+      "DatePending",
+      "UnderContractDate",
+      "ContractDate",
+      "LeasePending",
+      "PendingLeaseDate",
+      "LeaseAgreementDate"
+    ],
+    "level": "core"
   },
   "CloseDate": {
+    "definition": "With for-sale listings, the date the purchase agreement was fulfilled. With lease listings, the date the requirements were fulfilled, such as contract and/or deposit.  This is the date entered by the agent reflecting when the change occurred contractually, not a timestamp of when the change was made in the MLS.",
     "type": "date",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "maxLength": 10,
+    "synonyms": [
+      "SoldDate",
+      "DateSold",
+      "COE",
+      "COEDate",
+      "CloseDate",
+      "DateLeased",
+      "DateRented",
+      "DateLeaseBegins",
+      "EffectiveLeaseDate"
+    ],
+    "level": "core"
   },
   "OnMarketDate": {
+    "definition": "The date the listing was placed on market. Where possible, this date is reflective of the date entered by the agent reflecting when the change occurred contractually, not a timestamp of when the change was made in the MLS.",
     "type": "date",
-    "level": "core",
-    "path": "/Property/Listing"
+    "maxLength": 10,
+    "level": "core"
   },
   "OffMarketDate": {
+    "definition": "The date the listing was taken off market. Where possible, this date is reflective of the date entered by the agent reflecting when the change occurred contractually, not a timestamp of when the change was made in the MLS.",
     "type": "date",
-    "level": "core",
-    "path": "/Property/Listing"
+    "maxLength": 10,
+    "synonyms": [
+      "OffMarketDate",
+      "DateOffMarket"
+    ],
+    "level": "core"
   },
   "PendingTimestamp": {
+    "definition": "The transactional timestamp automatically recorded by the MLS system representing the most recent date/time the listing's status was set to Pending.",
     "type": "date",
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 27,
+    "level": "bronze"
   },
   "ModificationTimestamp": {
+    "definition": "The transactional timestamp automatically recorded by the MLS system representing the date/time the listing was last modified.",
     "type": "date",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "maxLength": 27,
+    "synonyms": [
+      "ModificationDateTime",
+      "DateTimeModified",
+      "ModDate",
+      "DateMod",
+      "UpdateDate",
+      "UpdateTimestamp"
+    ],
+    "level": "core"
   },
   "StatusChangeTimestamp": {
+    "definition": "The transactional timestamp automatically recorded by the MLS system representing the date/time the listing's status was last changed.",
     "type": "date",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "maxLength": 27,
+    "synonyms": [
+      "StatusDateTime"
+    ],
+    "level": "core"
   },
   "PriceChangeTimestamp": {
+    "definition": "The transactional timestamp automatically recorded by the MLS system representing the date/time the listing's price was last changed.",
     "type": "date",
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "maxLength": 27,
+    "synonyms": [
+      "PriceChangeDateTime",
+      "PriceChange"
+    ],
+    "level": "bronze"
   },
   "MajorChangeType": {
+    "definition": "Description of the last major change on the listing, i.e. “price reduction”, “back on market”, etc.  May be used to display on a summary view of listing results to quickly identify listings that have had major changes recently.",
     "type": "string",
     "maxLength": 255,
     "lookup": "ChangeType",
     "level": "bronze",
-    "path": "/Property/Listing",
     "enum": [
       "Active",
       "Active Under Contract",
@@ -250,79 +364,151 @@
     ]
   },
   "MajorChangeTimestamp": {
+    "definition": "Timestamp of the last major change on the listing (see also MajorChangeType).",
     "type": "date",
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 27,
+    "level": "bronze"
   },
   "OriginalEntryTimestamp": {
+    "definition": "The transactional timestamp automatically recorded by the MLS system representing the date/time the listing was entered and made visible to members of the MLS.",
     "type": "date",
-    "level": "core",
-    "path": "/Property/Listing"
+    "maxLength": 27,
+    "synonyms": [
+      "EntryDate",
+      "InputDate",
+      "DateTimeCreated",
+      "CreatedDate."
+    ],
+    "level": "core"
   },
   "OnMarketTimestamp": {
+    "definition": "The transactional timestamp automatically recorded by the MLS system representing the most recent date/time the listing's status was set to Active or Backup.  This also includes initial input of the listing to Active/Backup or from a draft or approval status to Active/Backup.",
     "type": "date",
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 27,
+    "level": "bronze"
   },
   "OffMarketTimestamp": {
+    "definition": "The transactional timestamp automatically recorded by the MLS system representing the most recent date/time the listing's status was set to and off market status (not Active or Backup)",
     "type": "date",
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 27,
+    "level": "bronze"
   },
   "DaysOnMarket": {
+    "definition": "The number of days the listing is on market, as defined by the MLS business rules.",
     "type": "number",
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 4,
+    "synonyms": [
+      "DOM",
+      "ListingDaysOnMarket",
+      "DOML",
+      "LDOM",
+      "ADOM",
+      "ActiveDaysOnMarket",
+      "AgentDaysOnMarket"
+    ],
+    "level": "bronze"
   },
   "CumulativeDaysOnMarket": {
+    "definition": "The number of days the property is on market, as defined by the MLS business rules.",
     "type": "number",
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 4,
+    "synonyms": [
+      "CDOM",
+      "PropertyDaysOnMarket",
+      "DOMP",
+      "PDOM"
+    ],
+    "level": "bronze"
   },
   "ClosePrice": {
+    "definition": "The amount of money paid by the purchaser to the seller for the property under the agreement.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "synonyms": [
+      "SellingPrice",
+      "SoldPrice",
+      "SalePrice",
+      "PriceSold",
+      "LeasePrice",
+      "RentalPrice",
+      "PurchasePrice",
+      "CurrentPrice"
+    ],
+    "level": "core"
   },
   "ListPrice": {
+    "definition": "The current price of the property as determined by the seller and the seller's broker.  For auctions this is the minimum or reserve price.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "synonyms": [
+      "AskingPrice",
+      "PriceListing",
+      "PriceListed",
+      "CurrentPrice"
+    ],
+    "level": "core"
   },
   "OriginalListPrice": {
+    "definition": "The original price of the property on the initial agreement between the seller and the seller's broker.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "core",
-    "path": "/Property/Listing"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "synonyms": [
+      "OriginalPrice"
+    ],
+    "level": "core"
   },
   "ListPriceLow": {
+    "definition": "The lower price used for Value Range Pricing.  The List Price must be greater than or equal to the ListPriceLow.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "synonyms": [
+      "LowPriceRange",
+      "LowRangePrice"
+    ],
+    "level": "bronze"
   },
   "PreviousListPrice": {
+    "definition": "The most recent previous ListPrice of the listing.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "synonyms": [
+      "PreviousPrice",
+      "LastPrice",
+      "ListPriorPrice"
+    ],
+    "level": "bronze"
   },
   "BuyerAgencyCompensation": {
+    "definition": "The total commission to be paid for this sale, expressed as either a percentage or a constant currency amount.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "SOComp",
+      "SellingOfficeCompensation",
+      "BuyerBrokerCompensation",
+      "SOC",
+      "Commission"
+    ],
+    "level": "core"
   },
   "BuyerAgencyCompensationType": {
+    "definition": "A list of types to clarify the value entered in the BuyerAgencyCompensation field.  For example $, % or some other clarification of the BuyerAgencyCompensation.",
     "type": "string",
     "maxLength": 25,
+    "synonyms": [
+      "SOCompType",
+      "SellingOfficeCompensationType",
+      "BuyerBrokerCompensationType",
+      "SOCType",
+      "CommissionType"
+    ],
     "lookup": "CompensationType",
     "level": "core",
-    "path": "/Property/Listing",
     "enum": [
       "$",
       "%",
@@ -330,17 +516,25 @@
     ]
   },
   "SubAgencyCompensation": {
+    "definition": "The total commission to be paid to the Sub Agency, expressed as either a percentage or a constant currency amount.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "SubAgentCompensation",
+      "CoBrokerCompensation"
+    ],
+    "level": "bronze"
   },
   "SubAgencyCompensationType": {
+    "definition": "A list of types to clarify the value entered in the SubAgencyCompensation field.  For example $, % or some other clarification of the SubAgencyCompensation.",
     "type": "string",
     "maxLength": 25,
+    "synonyms": [
+      "SubAgentCompensationType",
+      "CoBrokerCompensationType"
+    ],
     "lookup": "CompensationType",
     "level": "bronze",
-    "path": "/Property/Listing",
     "enum": [
       "$",
       "%",
@@ -348,17 +542,17 @@
     ]
   },
   "TransactionBrokerCompensation": {
+    "definition": "The total commission to be paid to the transaction facilitator, expressed as either a percentage or a constant currency amount.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "TransactionBrokerCompensationType": {
+    "definition": "A list of types to clarify the value entered in the TransactionBrokerCompensation field.  For example $, % or some other clarification of the TransactionBrokerCompensation.",
     "type": "string",
     "maxLength": 25,
     "lookup": "CompensationType",
     "level": "bronze",
-    "path": "/Property/Listing",
     "enum": [
       "$",
       "%",
@@ -366,17 +560,23 @@
     ]
   },
   "DualVariableCompensationYN": {
+    "definition": "A commission arrangement in which the seller agrees to pay a specified commission to the listing broker if the property is sold through the efforts of a cooperating broker, but the seller pays the Listing broker a different commission amount if the sale occurs if:1) there is no cooperating broker involved or 2) due to the efforts of the seller directly.",
     "type": "boolean",
-    "level": "core",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "DualVariableCompensation",
+      "DualVariableRateCompensation",
+      "VariableCompensation"
+    ],
+    "level": "core"
   },
   "LeaseRenewalCompensation": {
+    "definition": "A list of compensations other than the original Selling Office Compensation.  i.e. Compensation Paid on Renewal, Compensation Paid on Tennant Purchase, No Renewal Commission, Call Listing Office, etc.",
     "type": [
       "string"
     ],
+    "maxLength": 255,
     "lookup": "LeaseRenewalCompensation",
     "level": "bronze",
-    "path": "/Property/Listing",
     "enum": [
       "Call Listing Agent",
       "Call Listing Office",
@@ -386,149 +586,174 @@
     ]
   },
   "SignOnPropertyYN": {
+    "definition": "Is there a sign on the property.",
     "type": "boolean",
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "InternetEntireListingDisplayYN": {
+    "definition": "A yes/no field that states the seller has allowed the listing to be displayed on Internet sites.",
     "type": "boolean",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "InternetAddressDisplayYN": {
+    "definition": "A yes/no field that states the seller has allowed the listing address to be displayed on Internet sites.",
     "type": "boolean",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "InternetConsumerCommentYN": {
+    "definition": "A yes/no field that states the seller allows a comment or blog system to be attached to the listing on Internet sites.",
     "type": "boolean",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "InternetAutomatedValuationDisplayYN": {
+    "definition": "A yes/no field that states the seller allows the listing can be displayed with an AVM on Internet sites.",
     "type": "boolean",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "SyndicateTo": {
+    "definition": "When permitted by the broker, the options made by the agent on behalf of the seller, where they would like their listings syndicated.  i.e. Zillow, Trulia, Homes.com, etc.",
     "type": [
       "string"
     ],
-    "level": "gold",
-    "path": "/Property/Listing"
+    "maxLength": 1024,
+    "level": "gold"
   },
   "PhotosCount": {
+    "definition": "The total number of pictures or photos included with the listing.",
     "type": "number",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "maxLength": 2,
+    "synonyms": [
+      "PhotoCount"
+    ],
+    "level": "core"
   },
   "PhotosChangeTimestamp": {
+    "definition": "System generated timestamp of when the last update or change to the photos for this listing was made.",
     "type": "date",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "maxLength": 27,
+    "synonyms": [
+      "PhotoChangeTimestamp"
+    ],
+    "level": "core"
   },
   "VideosCount": {
+    "definition": "The total number of videos or virtual tours included with the listing.",
     "type": "number",
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 2,
+    "level": "bronze"
   },
   "VideosChangeTimestamp": {
+    "definition": "System generated timestamp of when the last update or change to the videos for this listing was made.",
     "type": "date",
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 27,
+    "level": "bronze"
   },
   "DocumentsCount": {
+    "definition": "The total number of documents or supplements included with the listings.",
     "type": "number",
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 2,
+    "level": "bronze"
   },
   "DocumentsChangeTimestamp": {
+    "definition": "System generated timestamp of when the last update or change to the documents for this listing was made.",
     "type": "date",
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 27,
+    "level": "bronze"
   },
   "DocumentsAvailable": {
+    "definition": "A list of the Documents available for the property.  Knowing what documents are available for the property is valuable information.\r\n",
     "type": [
       "string"
     ],
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 1024,
+    "level": "bronze"
   },
   "VirtualTourURLUnbranded": {
+    "definition": "A text field that holds the URL for an unbranded virtual tour of the property.",
     "type": "string",
     "maxLength": 8000,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "VirtualTourURLBranded": {
+    "definition": "A text field that holds the URL for a branded virtual tour of the property.",
     "type": "string",
     "maxLength": 8000,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "PublicRemarks": {
+    "definition": "Text remarks that may be displayed to the public. In an MLS, it is the field where information is entered for the public. This information is intended to be visible on-line. This is typically information that describes the selling points of the building and/or land for sale. Local conditions and rules will determine what such content can contain. Generally, the following information is excluded: any information pertaining to entry to the property, the seller and/or tenant, listing member contact information. In other systems, these remarks will be determined by local business rules.",
     "type": "string",
     "maxLength": 4000,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "PropertyDescription",
+      "InternetRemarks",
+      "Remarks"
+    ],
+    "level": "core"
   },
   "SyndicationRemarks": {
+    "definition": "Becoming more common in the industry, MLS's are hosting a separate \"Public Remarks\" for syndication purposes.  This field should be defaulted to containing the Public Remarks, but upon broker decision, modified to include contact and other information denied by IDX rules, but allowed under local and national regulations.",
     "type": "string",
     "maxLength": 4000,
-    "level": "core",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "AdvertisingRemarks"
+    ],
+    "level": "core"
   },
   "PrivateRemarks": {
+    "definition": "Remarks that may contain security or proprietary information and should be restricted from public view.",
     "type": "string",
     "maxLength": 4000,
-    "level": "core",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "AgentRemarks",
+      "ConfidentialRemarks"
+    ],
+    "level": "core"
   },
   "PrivateOfficeRemarks": {
+    "definition": "A remarks field that is only visible to members of the same offices as the listing agent.",
     "type": "string",
     "maxLength": 4000,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ShowingInstructions": {
+    "definition": "Remarks that detail the seller's instructions for showing the subject property. Showing instructions may include: contact information, showing times, notice required or other information. These remarks are privileged and are not for public viewing.",
     "type": "string",
     "maxLength": 4000,
-    "level": "core",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "ShowingRemarks"
+    ],
+    "level": "core"
   },
   "ShowingContactPhone": {
+    "definition": "A telephone number that should be called to arrange showing the property.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "ShowingPhone"
+    ],
+    "level": "core"
   },
   "ShowingContactPhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ShowingContactName": {
+    "definition": "The name of the contact for the showing of the listed property.",
     "type": "string",
     "maxLength": 40,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ShowingContactType": {
+    "definition": "The type of contact for the showing.  i.e. Agent, Broker, Seller.",
     "type": [
       "string"
     ],
+    "maxLength": 75,
     "lookup": "ShowingContactType",
     "level": "bronze",
-    "path": "/Property/Listing",
     "enum": [
       "Agent",
       "Occupant",
@@ -537,18 +762,25 @@
     ]
   },
   "LockBoxLocation": {
+    "definition": "A field describing the location of the lock box.",
     "type": "string",
     "maxLength": 255,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "KeySafeLocation"
+    ],
+    "level": "bronze"
   },
   "LockBoxType": {
+    "definition": "A field describing the type of lock box.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
+    "synonyms": [
+      "KeySafeType"
+    ],
     "lookup": "LockBoxType",
     "level": "bronze",
-    "path": "/Property/Listing",
     "enum": [
       "Call Listing Office",
       "Call Seller Direct",
@@ -560,52 +792,74 @@
     ]
   },
   "LockBoxSerialNumber": {
+    "definition": "The serial number of the lockbox placed on the property.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "KeySafeSerialNumber."
+    ],
+    "level": "bronze"
   },
   "AccessCode": {
+    "definition": "If the property is located behind an unmanned security gate such as in a Gated Community, what is the code to gain access through the secured gate.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "GateCode"
+    ],
+    "level": "bronze"
   },
   "Exclusions": {
+    "definition": "Elements of the property that will not be included in the sale.  i.e. Chandeliers will be removed prior to close.",
     "type": "string",
     "maxLength": 1024,
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "ExclusionRemarks"
+    ],
+    "level": "bronze"
   },
   "Inclusions": {
+    "definition": "Portable elements of the property that will be included in the sale.",
     "type": "string",
     "maxLength": 1024,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "InclusionRemarks"
+    ],
+    "level": "bronze"
   },
   "Disclosures": {
+    "definition": "Legal or pertinent information that should be disclosed to potential buyer's agents.",
     "type": [
       "string"
     ],
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 4000,
+    "synonyms": [
+      "Legal",
+      "LegalDisclosures"
+    ],
+    "level": "bronze"
   },
   "Ownership": {
+    "definition": "A text description of the manner in which title to a property is held.  Trust, Corporation, Joint Tennant, Individual.",
     "type": "string",
     "maxLength": 1024,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "silver"
   },
   "SpecialListingConditions": {
+    "definition": "A list of options that describe the type of sale.  i.e. Standard, REO, Short Sale, Probate, Auction, NOD, etc., at the time of listing.",
     "type": [
       "string"
+    ],
+    "maxLength": 1024,
+    "synonyms": [
+      "SaleType",
+      "REO",
+      "ShortSale",
+      "NoticeOfDefault",
+      "Foreclosure"
     ],
     "lookup": "SpecialListingConditions",
     "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property/Listing",
     "enum": [
       "Auction",
       "HUD Owned",
@@ -620,12 +874,16 @@
     ]
   },
   "ListingTerms": {
+    "definition": "Terms of the listing such as Lien Release, Subject to Court Approval or Owner Will Carry. Also may include options that describe the financing terms that are acceptable to the seller, i.e. cash, assumable, FHA loan, etc.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
+    "synonyms": [
+      "Terms"
+    ],
     "lookup": "ListingTerms",
     "level": "bronze",
-    "path": "/Property/Listing",
     "enum": [
       "1031 Exchange",
       "All Inclusive Trust Deed",
@@ -656,12 +914,13 @@
     ]
   },
   "CurrentFinancing": {
+    "definition": "A list of options that describe the type of financing that the seller currently has in place for the property being sold.  i.e. cash, assumable, FHA loan, etc.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "CurrentFinancing",
     "level": "bronze",
-    "path": "/Property/Listing",
     "enum": [
       "Assumable",
       "Contract",
@@ -681,12 +940,13 @@
     ]
   },
   "BuyerFinancing": {
+    "definition": "A list of options that describe the type of financing used.  This field is used when setting a listing to Closed.  i.e. cash, FHA loan, etc.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "BuyerFinancing",
     "level": "bronze",
-    "path": "/Property/Listing",
     "enum": [
       "Assumed",
       "Cash",
@@ -704,11 +964,11 @@
     ]
   },
   "Concessions": {
+    "definition": "Are there concessions included in the sales agreement? Yes, No or Call Listing Agent",
     "type": "string",
     "maxLength": 25,
     "lookup": "Concessions",
     "level": "silver",
-    "path": "/Property/Listing",
     "enum": [
       "Call Listing Agent",
       "No",
@@ -716,29 +976,34 @@
     ]
   },
   "ConcessionsComments": {
+    "definition": "Comments describing the concessions made by the buyer or the seller.",
     "type": "string",
     "maxLength": 200,
-    "level": "silver",
-    "path": "/Property/Listing"
+    "level": "silver"
   },
   "ConcessionsAmount": {
+    "definition": "The dollar amount of the concessions.  If the concessions are made by the seller, some may subtract this value from the sales price as a means of calculating their own true price.  If concessions are made by the buyer, some may add this amount to the sale price to create their own true price.  Concessions made by both buyer and seller should be subtracted from each other providing a net value.  Details of this calculation should be added to the Concessions Comments field.",
     "type": "number",
-    "level": "silver",
-    "path": "/Property/Listing"
+    "maxLength": 11,
+    "level": "silver"
   },
   "Contingency": {
+    "definition": "A list of contingencies that must be satisfied in order to complete the transaction.",
     "type": "string",
     "maxLength": 1024,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "Contingencies"
+    ],
+    "level": "bronze"
   },
   "Possession": {
+    "definition": "A list defining when possession will occur.  i.e. COE, COE+1, etc.",
     "type": [
       "string"
     ],
+    "maxLength": 255,
     "lookup": "Possession",
     "level": "bronze",
-    "path": "/Property/Listing",
     "enum": [
       "Close Of Escrow",
       "Close Plus 1 Day",
@@ -754,30 +1019,29 @@
     ]
   },
   "AvailabilityDate": {
+    "definition": "The date the property will be available for possession/occupation.",
     "type": "date",
-    "level": "silver",
-    "path": "/Property/Listing"
+    "maxLength": 10,
+    "level": "silver"
   },
   "StreetNumber": {
+    "definition": "The street number portion of a listed property's street address.  In some areas the street number may contain non-numeric characters.  This field can also contain extensions and modifiers to the street number, such as \"1/2\" or \"-B\".  This street number field should not include Prefixes, Direction or Suffixes.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "StreetNumberNumeric": {
+    "definition": "The integer portion of the street number.",
     "type": "number",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "maxLength": 10,
+    "level": "core"
   },
   "StreetDirPrefix": {
+    "definition": "The direction indicator that precedes the listed property's street name.",
     "type": "string",
     "maxLength": 15,
     "lookup": "StreetDirection",
     "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing",
     "enum": [
       "E",
       "N",
@@ -790,40 +1054,39 @@
     ]
   },
   "StreetName": {
+    "definition": "The street name portion of a listed property's street address.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "StreetAdditionalInfo": {
+    "definition": "Information other than a prefix or suffix for the street portion of a postal address.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "StreetSuffix": {
+    "definition": "The suffix portion of a listed property's street address.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "StreetSuffixModifier": {
+    "definition": "The Street Suffix Modifier allows the member to enter a unique Street Suffix that was not found in the Street Suffix pick list or to extend or prefix the suffix.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "Street Suffix Alternate",
+      "Street Suffix Extension."
+    ],
+    "level": "core"
   },
   "StreetDirSuffix": {
+    "definition": "The direction indicator that follows a listed property's street address.",
     "type": "string",
     "maxLength": 15,
     "lookup": "StreetDirection",
     "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing",
     "enum": [
       "E",
       "N",
@@ -836,26 +1099,28 @@
     ]
   },
   "UnitNumber": {
+    "definition": "Text field containing the number or portion of a larger building or complex. Unit Number should appear following the street suffix or, if it exists, the street suffix direction, in the street address. Examples are: \"APT G\", \"55\", etc.    ",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "ApartmentNumber",
+      "SpaceNumber",
+      "Suite"
+    ],
+    "level": "core"
   },
   "City": {
+    "definition": "The city in listing address.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "StateOrProvince": {
+    "definition": "Text field containing the accepted postal abbreviation for the state or province.",
     "type": "string",
     "maxLength": 2,
     "lookup": "StateOrProvince",
     "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing",
     "enum": [
       "AK",
       "AL",
@@ -925,12 +1190,11 @@
     ]
   },
   "Country": {
+    "definition": "The country abbreviation in a postal address.",
     "type": "string",
     "maxLength": 2,
     "lookup": "Country",
     "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing",
     "enum": [
       "AF",
       "AL",
@@ -1182,1124 +1446,1141 @@
     ]
   },
   "PostalCode": {
+    "definition": "The postal code portion of a street or mailing address.",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "ZipCode",
+      "Zip"
+    ],
+    "level": "core"
   },
   "PostalCodePlus4": {
+    "definition": "The postal code +4 portion of a street or mailing address.",
     "type": "string",
     "maxLength": 4,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "Zip+4",
+      "ZipPlus4"
+    ],
+    "level": "core"
   },
   "CarrierRoute": {
+    "definition": "The group of addresses to which the USPS assigns the same code to aid in mail delivery. For the USPS, these codes are 9 digits: 5 numbers for the ZIP Code, one letter for the carrier route type, and 3 numbers for the carrier route number.",
     "type": "string",
     "maxLength": 9,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "RR",
+      "CR"
+    ],
+    "level": "bronze"
   },
   "UnparsedAddress": {
+    "definition": "The UnparsedAddress is a text representation of the address with the full civic location as a single entity. It may optionally include any of City, StateOrProvince, PostalCode and Country.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "FullAddress"
+    ],
+    "level": "core"
   },
   "PostalCity": {
+    "definition": "The official city per the USPS.  May be different from the \"City\".",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CountyOrParish": {
+    "definition": "The County, Parish or other regional authority",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "County"
+    ],
+    "level": "core"
   },
   "Township": {
+    "definition": "A subdivision of the county.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "Municipality",
+      "TWP"
+    ],
+    "level": "core"
   },
   "MLSAreaMajor": {
+    "definition": "The major marketing area name, as defined by the MLS or other non-governmental organization.  If there is only one MLS Area in use, it must be the MLSAreaMajor.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "MarketingArea",
+      "MLSArea"
+    ],
+    "level": "core"
   },
   "MLSAreaMinor": {
+    "definition": "The minor/sub marketing area name, as defined by the MLS or other non-governmental organization.  If there is only one MLS Area in use, it must be the MLSAreaMajor.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "SubdivisionName": {
+    "definition": "A neighborhood, community, complex or builder tract.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "Builder's Tract"
+    ],
+    "level": "core"
   },
   "CityRegion": {
+    "definition": "A sub-section or area of a defined city.  Examples would be SOHO in New York, NY, Ironbound in Newark, NJ or Inside the Beltway.",
     "type": "string",
     "maxLength": 150,
-    "level": "platinum",
-    "path": "/Property/Listing"
+    "level": "platinum"
   },
   "StateRegion": {
+    "definition": "A sub-section or area of a defined state or province.  Examples would be the Keys in FL or Hudson Valley in NY.",
     "type": "string",
     "maxLength": 150,
-    "level": "platinum",
-    "path": "/Property/Listing"
+    "level": "platinum"
   },
   "CountryRegion": {
+    "definition": "A sub-section or area of a defined country.  Examples would be Napa Valley in the US, or the Amalfi Coast in Italy.",
     "type": "string",
     "maxLength": 150,
-    "level": "platinum",
-    "path": "/Property/Listing"
+    "level": "platinum"
   },
   "ContinentRegion": {
+    "definition": "A sub-section or area of a continent.  Examples would be Southern Europe or Scandinavia.",
     "type": "string",
     "maxLength": 150,
-    "level": "platinum",
-    "path": "/Property/Listing"
+    "level": "platinum"
   },
   "Latitude": {
+    "definition": "The geographic latitude of some reference point on the property, specified in degrees and decimal parts.  Positive numbers must not include the plus symbol.",
     "type": "number",
-    "maxPrecision": "8",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "maxLength": 12,
+    "maxPrecision": 8,
+    "level": "core"
   },
   "Longitude": {
+    "definition": "The geographic longitude of some reference point on the property, specified in degrees and decimal parts. Positive numbers must not include the plus symbol.",
     "type": "number",
-    "maxPrecision": "8",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "maxLength": 12,
+    "maxPrecision": 8,
+    "level": "core"
   },
   "Elevation": {
+    "definition": "The elevation of the property in relation to sea level.  Use the Elevation Units field to communicate the unit of measurement.  i.e. Feet or Meters.",
     "type": "number",
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 5,
+    "level": "bronze"
   },
   "ElevationUnits": {
+    "definition": "A pick list of the unit of measurement used in the Elevation field.  i.e. Feet, Meters.",
     "type": "string",
     "maxLength": 10,
     "lookup": "LinearUnits",
     "level": "bronze",
-    "path": "/Property/Listing",
     "enum": [
       "Feet",
       "Meters"
     ]
   },
   "Directions": {
+    "definition": "Driving directions to the property.",
     "type": "string",
     "maxLength": 1024,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "silver"
   },
   "MapCoordinate": {
+    "definition": "A map coordinate for the property, as determined by local custom. This is not necessarily the same as the geographic coordinate but may depend on the coordinate system used by whatever mapping service is customarily used by the listing service.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "MapBookCoordinate",
+      "ThomasGuide",
+      "TG#",
+      "MapBookNumber"
+    ],
+    "level": "bronze"
   },
   "MapCoordinateSource": {
+    "definition": "Name of the map or map book publisher.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "MapBook"
+    ],
+    "level": "bronze"
   },
   "MapURL": {
+    "definition": "URI to a map of the property.",
     "type": "string",
     "maxLength": 8000,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CrossStreet": {
+    "definition": "Nearest cross streets to the property.  This field is in addition to, and independent of, the driving directions field.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "silver"
   },
   "ElementarySchool": {
+    "definition": "The name of the primary school having a catchment area that includes the associated property.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "silver"
   },
   "ElementarySchoolDistrict": {
+    "definition": "The name of the elementary school district having a catchment area that includes the associated property.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "MiddleOrJuniorSchool": {
+    "definition": "The name of the junior or middle school having a catchment area that includes the associated property.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "silver"
   },
   "MiddleOrJuniorSchoolDistrict": {
+    "definition": "The name of the junior or middle school district having a catchment area that includes the associated property.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "HighSchool": {
+    "definition": "The name of the high school having a catchment area that includes the associated property.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "silver"
   },
   "HighSchoolDistrict": {
+    "definition": "The name of the high school district having a catchment area that includes the associated property.  When only one school district is used, this field should be used over the Junior or Elementary Districts.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "synonyms": [
+      "SchoolDistrict"
+    ],
+    "level": "bronze"
   },
   "ListAgentNamePrefix": {
+    "definition": "Prefix to the name (e.g. Dr. Mr. Ms. etc.)",
     "type": "string",
     "maxLength": 10,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ListAgentFirstName": {
+    "definition": "The first name of the listing agent.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListAgentMiddleName": {
+    "definition": "The middle name of the listing agent.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListAgentLastName": {
+    "definition": "The last name of the listing agent.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListAgentNameSuffix": {
+    "definition": "Suffix to the ListAgentLastName (e.g. Esq.,  Jr.,  III etc.)",
     "type": "string",
     "maxLength": 10,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ListAgentFullName": {
+    "definition": "The full name of the listing agent. (First Middle Last)",
     "type": "string",
     "maxLength": 150,
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ListAgentPreferredPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListAgentPreferredPhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListAgentOfficePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListAgentOfficePhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListAgentCellPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListAgentDirectPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ListAgentHomePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ListAgentFax": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ListAgentPager": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ListAgentVoiceMail": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ListAgentVoiceMailExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ListAgentTollFreePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ListAgentEmail": {
+    "definition": "The email address of the Listing Agent.",
     "type": "string",
     "maxLength": 80,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListAgentURL": {
+    "definition": "The website URI of the listing agent.",
     "type": "string",
     "maxLength": 8000,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ListAgentKey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the ListAgentKey is the system unique identifier from the system that the record was retrieved. This may be identical to the related xxxId. This is a foreign key relating to the Member resource's MemberKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListAgentKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the ListAgentKey is the system unique identifier from the system that the record was retrieved. This may be identical to the related xxxId. This is a foreign key relating to the Member resource's MemberKey. This is the numeric only key and used as an alternative to the ListAgentKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property/Listing"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "ListAgentAOR": {
+    "definition": "The Listing Agent's Board or Association of REALTORS.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ListAgentMlsId": {
+    "definition": "The local, well-known identifier for the member. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListAgentStateLicense": {
+    "definition": "The license of the listing agent. Separate multiple licenses with a comma and space.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListAgentDesignation": {
+    "definition": "Designations and certifications acknowledging experience and expertise in various real estate sectors are awarded by NAR and each affiliated group upon completion of required courses.",
     "type": [
       "string"
     ],
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 50,
+    "level": "bronze"
   },
   "ListOfficeName": {
+    "definition": "The legal name of the brokerage representing the seller.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListOfficePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListOfficePhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListOfficeFax": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ListOfficeEmail": {
+    "definition": "The email address of the Listing Office.",
     "type": "string",
     "maxLength": 80,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ListOfficeURL": {
+    "definition": "The website URI for the listing office.",
     "type": "string",
     "maxLength": 8000,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ListOfficeKey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Office resource's OfficeKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListOfficeKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Office resource's OfficeKey.  This is the numeric only key and used as an alternative to the ListOfficeKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property/Listing"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "ListOfficeAOR": {
+    "definition": "The Listing Office's Board or Association of REALTORS.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "ListOfficeMlsId": {
+    "definition": "The local, well-known identifier. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListAgentNamePrefix": {
+    "definition": "Prefix to the name (e.g. Dr. Mr. Ms. etc.)",
     "type": "string",
     "maxLength": 10,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoListAgentFirstName": {
+    "definition": "The first name of the co-listing agent.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListAgentMiddleName": {
+    "definition": "The middle name of the co-listing agent.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListAgentLastName": {
+    "definition": "The last name of the co-listing agent.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListAgentNameSuffix": {
+    "definition": "Suffix to the CoListAgentLastName (e.g. Esq.,  Jr.,  III etc.)",
     "type": "string",
     "maxLength": 10,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoListAgentFullName": {
+    "definition": "The full name of the co-listing agent. (First Middle Last)",
     "type": "string",
     "maxLength": 150,
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoListAgentPreferredPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListAgentPreferredPhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListAgentOfficePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListAgentOfficePhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListAgentCellPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListAgentDirectPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoListAgentHomePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoListAgentFax": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoListAgentPager": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoListAgentVoiceMail": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoListAgentVoiceMailExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoListAgentTollFreePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoListAgentEmail": {
+    "definition": "The email address of the Co Listing Agent.",
     "type": "string",
     "maxLength": 80,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListAgentURL": {
+    "definition": "The website URI of the co-listing agent.",
     "type": "string",
     "maxLength": 8000,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoListAgentKey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Member resource's MemberKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListAgentKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Member resource's MemberKey.  This is the numeric only key and used as an alternative to the CoListAgentKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property/Listing"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "CoListAgentAOR": {
+    "definition": "The Co Listing Agent's Board or Association of REALTORS.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoListAgentMlsId": {
+    "definition": "The local, well-known identifier. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListAgentStateLicense": {
+    "definition": "The license of the co-listing agent. Separate multiple licenses with a comma and space.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListAgentDesignation": {
+    "definition": "Designations and certifications acknowledging experience and expertise in various real estate sectors are awarded by NAR and each affiliated group upon completion of required courses.",
     "type": [
       "string"
     ],
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 50,
+    "level": "bronze"
   },
   "CoListOfficeName": {
+    "definition": "The legal name of the brokerage co-representing the seller.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListOfficePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListOfficePhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListOfficeFax": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoListOfficeEmail": {
+    "definition": "The email address of the Co Listing Office.",
     "type": "string",
     "maxLength": 80,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoListOfficeURL": {
+    "definition": "The website URI for the co-listing office.",
     "type": "string",
     "maxLength": 8000,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoListOfficeKey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Office resource's OfficeKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoListOfficeKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Office resource's OfficeKey.  This is the numeric only key and used as an alternative to the CoListOfficeKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property/Listing"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "CoListOfficeAOR": {
+    "definition": "The Co Listing Office's Board or Association of REALTORS.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoListOfficeMlsId": {
+    "definition": "The local, well-known identifier. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerAgentNamePrefix": {
+    "definition": "Prefix to the name (e.g. Dr. Mr. Ms. etc.)",
     "type": "string",
     "maxLength": 10,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "BuyerAgentFirstName": {
+    "definition": "The first name of the buyer's agent.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerAgentMiddleName": {
+    "definition": "The middle name of the buyer's agent.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerAgentLastName": {
+    "definition": "The last name of the buyer's agent.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerAgentNameSuffix": {
+    "definition": "Suffix to the BuyerAgentLastName (e.g. Esq.,  Jr.,  III etc.)",
     "type": "string",
     "maxLength": 10,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "BuyerAgentFullName": {
+    "definition": "The full name of the buyer's agent. (First Middle Last)",
     "type": "string",
     "maxLength": 150,
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "BuyerAgentPreferredPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerAgentPreferredPhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerAgentOfficePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerAgentOfficePhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerAgentCellPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerAgentDirectPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "BuyerAgentHomePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "BuyerAgentFax": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "BuyerAgentPager": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "BuyerAgentVoiceMail": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "BuyerAgentVoiceMailExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "BuyerAgentTollFreePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "BuyerAgentEmail": {
+    "definition": "The email address of the Buyer's Agent.",
     "type": "string",
     "maxLength": 80,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerAgentURL": {
+    "definition": "The website URI of the buyers agent.",
     "type": "string",
     "maxLength": 8000,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "BuyerAgentKey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Member resource's MemberKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerAgentKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Member resource's MemberKey.  This is the numeric only key and used as an alternative to the BuyerAgentKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property/Listing"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "BuyerAgentAOR": {
+    "definition": "The Buyer's Agent's Board or Association of REALTORS.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "BuyerAgentMlsId": {
+    "definition": "The local, well-known identifier. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerAgentStateLicense": {
+    "definition": "The license of the buyers agent. Separate multiple licenses with a comma and space.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerAgentDesignation": {
+    "definition": "Designations and certifications acknowledging experience and expertise in various real estate sectors are awarded by NAR and each affiliated group upon completion of required courses.",
     "type": [
       "string"
     ],
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 50,
+    "level": "bronze"
   },
   "BuyerOfficeName": {
+    "definition": "The legal name of the brokerage representing the buyer.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerOfficePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerOfficePhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerOfficeFax": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "BuyerOfficeEmail": {
+    "definition": "The email address of the Buyer's Office.",
     "type": "string",
     "maxLength": 80,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "BuyerOfficeURL": {
+    "definition": "The website URI for the buyers office.",
     "type": "string",
     "maxLength": 8000,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "BuyerOfficeKey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Office resource's OfficeKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "BuyerOfficeKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Office resource's OfficeKey.  This is the numeric only key and used as an alternative to the BuyerOfficeKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property/Listing"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "BuyerOfficeAOR": {
+    "definition": "The Buyer's Office's Board or Association of REALTORS.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "BuyerOfficeMlsId": {
+    "definition": "The local, well-known identifier. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoBuyerAgentNamePrefix": {
+    "definition": "Prefix to the name (e.g. Dr. Mr. Ms. etc.)",
     "type": "string",
     "maxLength": 10,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerAgentFirstName": {
+    "definition": "The first name of the buyer's co-agent.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoBuyerAgentMiddleName": {
+    "definition": "The middle name of the buyer's co-agent.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoBuyerAgentLastName": {
+    "definition": "The last name of the buyer's co-agent.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoBuyerAgentNameSuffix": {
+    "definition": "Suffix to the CoBuyerAgentLastName (e.g. Esq.,  Jr.,  III etc.)",
     "type": "string",
     "maxLength": 10,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerAgentFullName": {
+    "definition": "The full name of the buyer's co-agent. (First Middle Last)",
     "type": "string",
     "maxLength": 150,
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerAgentPreferredPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoBuyerAgentPreferredPhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoBuyerAgentOfficePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoBuyerAgentOfficePhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoBuyerAgentCellPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoBuyerAgentDirectPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerAgentHomePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerAgentFax": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerAgentPager": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerAgentVoiceMail": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerAgentVoiceMailExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerAgentTollFreePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerAgentEmail": {
+    "definition": "The email address of the Buyer's Co Agent.",
     "type": "string",
     "maxLength": 80,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoBuyerAgentURL": {
+    "definition": "The website URI of the co-buyers agent.",
     "type": "string",
     "maxLength": 8000,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerAgentKey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Member resource's MemberKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoBuyerAgentKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Member resource's MemberKey.  This is the numeric only key and used as an alternative to the CoBuyerAgentKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property/Listing"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "CoBuyerAgentAOR": {
+    "definition": "The Co Buyer's Agent's Board or Association of REALTORS.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerAgentMlsId": {
+    "definition": "The local, well-known identifier. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoBuyerAgentStateLicense": {
+    "definition": "The license of the co-buyers agent. Separate multiple licenses with a comma and space.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerAgentDesignation": {
+    "definition": "Designations and certifications acknowledging experience and expertise in various real estate sectors are awarded by NAR and each affiliated group upon completion of required courses.",
     "type": [
       "string"
     ],
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "maxLength": 50,
+    "level": "bronze"
   },
   "CoBuyerOfficeName": {
+    "definition": "The legal name of the brokerage co-representing the buyer.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoBuyerOfficePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoBuyerOfficePhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoBuyerOfficeFax": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerOfficeEmail": {
+    "definition": "The email address of the Buyer's Co Office.",
     "type": "string",
     "maxLength": 80,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerOfficeURL": {
+    "definition": "The website URI for the co-buyers office.",
     "type": "string",
     "maxLength": 8000,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerOfficeKey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Office resource's OfficeKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "core",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "CoBuyerOfficeKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Office resource's OfficeKey.  This is the numeric only key and used as an alternative to the CoBuyerOfficeKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property/Listing"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "CoBuyerOfficeAOR": {
+    "definition": "The Co Buyer's Office's Board or Association of REALTORS.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Property/Listing"
+    "level": "bronze"
   },
   "CoBuyerOfficeMlsId": {
+    "definition": "The local, well-known identifier. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "core"
   },
   "ListTeamName": {
+    "definition": "The name of the team representing the seller.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Property/Listing"
+    "level": "silver"
   },
   "ListTeamKey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Teams resource's TeamKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Property/Listing"
+    "level": "silver"
   },
   "ListTeamKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Teams resource's TeamKey.  This is the numeric only key and used as an alternative to the ListTeamKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property/Listing"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "BuyerTeamName": {
+    "definition": "The name of the team representing the buyer.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property/Listing"
+    "level": "silver"
   },
   "BuyerTeamKey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Teams resource's TeamKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Property/Listing"
+    "level": "silver"
   },
   "BuyerTeamKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the Key is the system unique identifier from the system that the record was just retrieved. This may be identical to the related xxxId identifier, but the key is guaranteed unique for this record set.  This is a foreign key relating to the Teams resource's TeamKey.  This is the numeric only key and used as an alternative to the BuyerTeamKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property/Listing"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "PropertyType": {
+    "definition": "A list of types of properties such as Residential, Lease, Income, Land, Mobile, Commercial Sale, etc...",
     "type": "string",
     "maxLength": 50,
     "lookup": "PropertyType",
     "level": "core",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Residential",
       "Residential Lease",
@@ -2313,12 +2594,11 @@
     ]
   },
   "PropertySubType": {
+    "definition": "A list of types of residential and residential lease properties, i.e. SFR, Condo, etc. Or a list of Sub Types for Mobile, such as Expando, Manufactured, Modular, etc.",
     "type": "string",
     "maxLength": 50,
     "lookup": "PropertySubType",
     "level": "core",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Apartment",
       "Boat Slip",
@@ -2341,37 +2621,52 @@
     ]
   },
   "AssociationYN": {
+    "definition": "Is there a Home Owners Association.  A separate Y/N field is needed because not all associations have dues.",
     "type": "boolean",
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property"
+    "synonyms": [
+      "HOAYN"
+    ],
+    "level": "bronze"
   },
   "AssociationName": {
+    "definition": "The name of the Home Owners Association.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Property"
+    "synonyms": [
+      "HOAName"
+    ],
+    "level": "bronze"
   },
   "AssociationPhone": {
+    "definition": "The phone number of the Home Owners Association. North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property"
+    "synonyms": [
+      "HOAPhone"
+    ],
+    "level": "bronze"
   },
   "AssociationFee": {
+    "definition": "A fee paid by the homeowner to the Home Owners Association which is used for the upkeep of the common area, neighborhood or other association related benefits.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "synonyms": [
+      "HOAFee",
+      "CAM Charge",
+      "Condo Charge"
+    ],
+    "level": "bronze"
   },
   "AssociationFeeFrequency": {
+    "definition": "The frequency the association fee is paid.  For example, Weekly, Monthly, Annually, Bi-Monthly, One Time, etc.",
     "type": "string",
     "maxLength": 25,
+    "synonyms": [
+      "HOAFeeFrequency"
+    ],
     "lookup": "FeeFrequency",
     "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Daily",
       "Weekly",
@@ -2387,29 +2682,42 @@
     ]
   },
   "AssociationName2": {
+    "definition": "The name of the second of two Home Owners Association.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Property"
+    "synonyms": [
+      "HOAName2"
+    ],
+    "level": "bronze"
   },
   "AssociationPhone2": {
+    "definition": "The phone number of the second of two Home Owners Association. North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property"
+    "synonyms": [
+      "HOAPhone2"
+    ],
+    "level": "bronze"
   },
   "AssociationFee2": {
+    "definition": "A fee paid by the homeowner to the second of two Home Owners Associations, which is used for the upkeep of the common area, neighborhood or other association related benefits.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "bronze",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "synonyms": [
+      "HOAFee2"
+    ],
+    "level": "bronze"
   },
   "AssociationFee2Frequency": {
+    "definition": "The frequency the association fee is paid.  For example, Weekly, Monthly, Annually, Bi-Monthly, One Time, etc.",
     "type": "string",
     "maxLength": 25,
+    "synonyms": [
+      "HOAFeeFrequency2"
+    ],
     "lookup": "FeeFrequency",
     "level": "bronze",
-    "path": "/Property",
     "enum": [
       "Daily",
       "Weekly",
@@ -2425,13 +2733,16 @@
     ]
   },
   "AssociationFeeIncludes": {
+    "definition": "Services included with the association fee.  For example Landscaping, Trash, Water, etc.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
+    "synonyms": [
+      "HOAFeeIncludes"
+    ],
     "lookup": "AssociationFeeIncludes",
     "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Cable TV",
       "Earthquake Insurance",
@@ -2450,20 +2761,26 @@
     ]
   },
   "AssociationAmenities": {
+    "definition": "Amenities provided by the Home Owners Association, Mobile Park or Complex. For example Pool, Clubhouse, etc.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "synonyms": [
+      "AssociationRules",
+      "AssociationInfo",
+      "HOAAmenities"
+    ],
+    "level": "platinum"
   },
   "PetsAllowed": {
+    "definition": "Are pets allowed at the property being leased?  A list of yes, no and more detailed restrictions/allowances.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "PetsAllowed",
     "level": "silver",
-    "path": "/Property",
     "enum": [
       "Yes",
       "No",
@@ -2476,18 +2793,18 @@
     ]
   },
   "LotSizeArea": {
+    "definition": "The total area of the lot.  See Lot Size Units for the units of measurement (Square Feet, Square Meters, Acres, etc.).",
     "type": "number",
-    "maxPrecision": "4",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 16,
+    "maxPrecision": 4,
+    "level": "core"
   },
   "LotSizeSource": {
+    "definition": "The source of the measurements. This may be a pick list of options showing the source of the measurement. i.e. Agent, Assessor, Estimate, etc.",
     "type": "string",
     "maxLength": 50,
     "lookup": "LotSizeSource",
     "level": "bronze",
-    "path": "/Property",
     "enum": [
       "Appraiser",
       "Assessor",
@@ -2501,12 +2818,11 @@
     ]
   },
   "LotSizeUnits": {
+    "definition": "A pick list of the unit of measurement for the area.  i.e. Square Feet, Square Meters, Acres, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "LotSizeUnits",
     "level": "core",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Acres",
       "Square Feet",
@@ -2514,86 +2830,87 @@
     ]
   },
   "LotSizeDimensions": {
+    "definition": "The dimensions of the lot minimally represented as length and width (i.e. 250 x 180) or a measurement of all sides of the polygon representing the property lines of the property.  i.e. 30 x 50 x 120 x 60 x 22.",
     "type": "string",
     "maxLength": 150,
-    "level": "gold",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "gold"
   },
   "LotDimensionsSource": {
+    "definition": "The source of the measurements. This may be a pick list of options showing the source of the measurement. i.e. Agent, Assessor, Estimate, etc.",
     "type": "string",
     "maxLength": 50,
-    "level": "gold",
-    "path": "/Property"
+    "level": "gold"
   },
   "LotSizeAcres": {
+    "definition": "The total Acres of the lot.  This field is related to the Lot Size Area and Lot Size Units and must be in sync with the values represented in those fields.  Lot Size Source also applies to this field when used.",
     "type": "number",
-    "maxPrecision": "4",
-    "level": "gold",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 16,
+    "maxPrecision": 4,
+    "level": "gold"
   },
   "LotSizeSquareFeet": {
+    "definition": "The total square footage of the lot.  This field is related to the Lot Size Area and Lot Size Units and must be in sync with the values represented in those fields.  Lot Size Source also applies to this field when used.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "gold",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "gold"
   },
   "FrontageType": {
+    "definition": "Pick list of types of frontage.  i.e. Oceanfront, Lakefront, Golf course…etc.….  Information about roads or road frontage should be located in the Road Frontage Type and Road Surface Type fields.",
     "type": [
       "string"
     ],
-    "level": "gold",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "gold"
   },
   "FrontageLength": {
+    "definition": "Textual description of the length of the frontages selected in the Frontage Type field.",
     "type": "string",
     "maxLength": 255,
-    "level": "gold",
-    "path": "/Property"
+    "level": "gold"
   },
   "RoadFrontageType": {
+    "definition": "Pick list of types of Road frontage.  i.e. Freeway frontage, No Road Frontage, etc. The road frontage of the property is an important factor in determining value of the property and it’s appropriateness for intended use.",
     "type": [
       "string"
     ],
-    "level": "gold",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "gold"
   },
   "RoadSurfaceType": {
+    "definition": "Pick list of types of surface of the Road to access the property.  The surface of the road(s) for access to the property is an important factor in determining value of the property and it’s appropriateness for intended use.",
     "type": [
       "string"
     ],
-    "level": "gold",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "gold"
   },
   "RoadResponsibility": {
+    "definition": "The person or entity responsible for road maintenance (e.g., City, County, Private).",
     "type": [
       "string"
     ],
-    "level": "gold",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "gold"
   },
   "OccupantName": {
+    "definition": "Name of the current occupant, if any, of the property being sold.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "OccupantPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "OccupantType": {
+    "definition": "A field that describes the type of occupant, i.e. Owner, Tenant, Vacant.",
     "type": "string",
     "maxLength": 50,
     "lookup": "OccupantType",
     "level": "bronze",
-    "path": "/Property",
     "enum": [
       "Owner",
       "Tenant",
@@ -2601,30 +2918,29 @@
     ]
   },
   "OwnerName": {
+    "definition": "Name of the owner of the property being sold.",
     "type": "string",
     "maxLength": 50,
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "OwnerPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "AnchorsCoTenants": {
+    "definition": "The main or most notable tenants as well as other tenants of the shopping center or mall in which the commercial property is located.",
     "type": "string",
     "maxLength": 1024,
-    "level": "platinum",
-    "path": "/Property"
+    "level": "platinum"
   },
   "LeaseTerm": {
+    "definition": "A pick list of lengths that represent the length of the lease.  i.e. Weekly, Month to Month, 6 Month Lease, 12 Month Lease, 24 Month Lease.",
     "type": "string",
     "maxLength": 25,
     "lookup": "LeaseTerm",
     "level": "core",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "12 Months",
       "24 Months",
@@ -2639,22 +2955,32 @@
     ]
   },
   "LandLeaseYN": {
+    "definition": "The land is not included in the sale and a lease exists.",
     "type": "boolean",
-    "level": "core",
-    "path": "/Property"
+    "synonyms": [
+      "LandFeeLease"
+    ],
+    "level": "core"
   },
   "LandLeaseAmount": {
+    "definition": "When the land is not included in the sale, but is leased, the amount of the lease.  This is the Space Rent for Mobile homes in a Park.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "bronze",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "synonyms": [
+      "SpaceRent"
+    ],
+    "level": "bronze"
   },
   "LandLeaseAmountFrequency": {
+    "definition": "When the land is not included in the sale, but is leased, the frequency the Land Lease Fee is paid.",
     "type": "string",
     "maxLength": 25,
+    "synonyms": [
+      "FeeFrequency"
+    ],
     "lookup": "FeeFrequency",
     "level": "bronze",
-    "path": "/Property",
     "enum": [
       "Daily",
       "Weekly",
@@ -2670,165 +2996,193 @@
     ]
   },
   "LandLeaseExpirationDate": {
+    "definition": "When the land is not included in the sale, but is leased, the expiration date of the Land Lease.",
     "type": "date",
-    "level": "bronze",
-    "path": "/Property"
+    "maxLength": 10,
+    "level": "bronze"
   },
   "View": {
+    "definition": "A view as seen from the listed property.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "ViewYN": {
+    "definition": "The property has a view.",
     "type": "boolean",
-    "level": "platinum",
-    "path": "/Property"
+    "level": "platinum"
   },
   "LotFeatures": {
+    "definition": "A list of features or description of the lot included in the sale/lease.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "CurrentUse": {
+    "definition": "A list of the type(s) of current use of the property. The current use of the property is an important factor in understanding the overall condition of the land and determining it’s appropriateness for intended use.\r\n",
     "type": [
       "string"
     ],
-    "level": "gold",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "gold"
   },
   "PossibleUse": {
+    "definition": "A list of the type(s) of possible or best uses of the property.  Probable use gives a good indication of what the best use or potential use of the property could be.\r\ni.e. Primary, Vacation, Investment, Rental, Retirement ",
     "type": [
       "string"
     ],
-    "level": "gold",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "gold"
   },
   "DevelopmentStatus": {
+    "definition": "A list of the Development Status of the property.  The developmental status of land is an important factor in selling, purchasing and developing of land properties.\r\n",
     "type": [
       "string"
     ],
-    "level": "gold",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "gold"
   },
   "NumberOfLots": {
+    "definition": "Total number of lots on the property or included in the sale. Land properties are often sold with multiple lots. It is important to be able to describe how many lots are in the property and not in all cases do lots have separate Parcel IDs.",
     "type": "number",
-    "level": "bronze",
-    "path": "/Property"
+    "maxLength": 3,
+    "level": "bronze"
   },
   "Topography": {
+    "definition": "The state of the surface of the land included with the property.  i.e. flat, rolling, etc.",
     "type": "string",
     "maxLength": 255,
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "platinum"
   },
   "HorseYN": {
+    "definition": "The Property is allowed to raise horses.",
     "type": "boolean",
-    "level": "platinum",
-    "path": "/Property"
+    "level": "platinum"
   },
   "HorseAmenities": {
+    "definition": "A list of horse amenities on the lot or in the community.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "CommunityFeatures": {
+    "definition": "A list of features related to, or available within, the community.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "NumberOfUnitsInCommunity": {
+    "definition": "The total number of units in the building, complex or community.  This is not the number of units being sold, but rather the size of the community in which the dwelling being sold is located.",
     "type": "number",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 5,
+    "level": "silver"
   },
   "SeniorCommunityYN": {
+    "definition": "The community is a senior community.",
     "type": "boolean",
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "platinum"
   },
   "PoolFeatures": {
+    "definition": "A list of features or description of the pool included in the sale/lease.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "PoolPrivateYN": {
+    "definition": "The property has a privately owned pool that is included in the sale/lease.",
     "type": "boolean",
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "platinum"
   },
   "SpaFeatures": {
+    "definition": "A list of features or description of the spa included in the sale/lease.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "SpaYN": {
+    "definition": "The property has a spa.",
     "type": "boolean",
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "synonyms": [
+      "Jacuzzi",
+      "HotTub"
+    ],
+    "level": "platinum"
   },
   "WaterfrontYN": {
+    "definition": "The property is on the waterfront.",
     "type": "boolean",
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "synonyms": [
+      "Lakefront",
+      "Oceanfront",
+      "Riverfront"
+    ],
+    "level": "platinum"
   },
   "WaterfrontFeatures": {
+    "definition": "Features of the waterfront on which the property is located.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "synonyms": [
+      "LakefrontFeatures",
+      "OceanfrontFeatures",
+      "RiverfrontFeatures"
+    ],
+    "level": "platinum"
   },
   "WaterBodyName": {
+    "definition": "The name, if known, of the body of water on which the property is located. (E.g., lake name, river name, ocean name, sea name, canal name).",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "synonyms": [
+      "LakeName",
+      "RiverName",
+      "OceanName"
+    ],
+    "level": "platinum"
   },
   "GrossScheduledIncome": {
+    "definition": "The maximum amount of annual rent collected if the property were 100% occupied all year and all tenants paid their rent.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "core",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "synonyms": [
+      "Proforma Income"
+    ],
+    "level": "core"
   },
   "GrossIncome": {
+    "definition": "The actual current income from rent and all other revenue generating sources.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "core",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "synonyms": [
+      "Current Income",
+      "Actual Income"
+    ],
+    "level": "core"
   },
   "IncomeIncludes": {
+    "definition": "A list of income sources included in the GrossScheduledIncome and GrossIncome.  i.e. Laundry, Parking, Recreation, Storage, etc.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "IncomeIncludes",
     "level": "bronze",
-    "path": "/Property",
     "enum": [
       "Laundry",
       "Parking",
@@ -2839,18 +3193,20 @@
     ]
   },
   "OperatingExpense": {
+    "definition": "The costs associated with the operation and maintenance of an income-producing property.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "core",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "core"
   },
   "OperatingExpenseIncludes": {
+    "definition": "When individual expense fields are not used and only a total is entered, this lists the expenses that are included in the OperatingExpense field.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "OperatingExpenseIncludes",
     "level": "bronze",
-    "path": "/Property",
     "enum": [
       "Accounting",
       "Advertising",
@@ -2888,41 +3244,48 @@
     ]
   },
   "NetOperatingIncome": {
+    "definition": "Net operating income is the revenue from a property after operating expenses have been deducted, but before deducting income taxes and financing expenses (interest and Principal Payments).   For example, Gross Income - Operating Expenses = Net Operating Income (NOI).",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "core",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "core"
   },
   "CapRate": {
+    "definition": "Cap Rate is equivalent to the return on investment you would receive if you pay cash for a property. The ratio between the net operating income produced by an asset and its capital cost (the original price paid to buy the asset) or alternatively its current market value.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 5,
+    "maxPrecision": 2,
+    "synonyms": [
+      "CapitalizationRate"
+    ],
+    "level": "core"
   },
   "NumberOfUnitsLeased": {
+    "definition": "Total number of units currently under a lease agreement.",
     "type": "number",
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 5,
+    "level": "bronze"
   },
   "NumberOfUnitsMoMo": {
+    "definition": "The total number of units leasable month to month.",
     "type": "number",
-    "level": "bronze",
-    "path": "/Property"
+    "maxLength": 5,
+    "level": "bronze"
   },
   "NumberOfUnitsVacant": {
+    "definition": "The number of units currently vacant.",
     "type": "number",
-    "level": "bronze",
-    "path": "/Property"
+    "maxLength": 5,
+    "level": "bronze"
   },
   "ExistingLeaseType": {
+    "definition": "Information about the status of the existing lease on the property.  i.e. Net, NNN, NN, Gross, Absolute Net, Escalation Clause, Ground Lease, etc.",
     "type": [
       "string"
     ],
+    "maxLength": 75,
     "lookup": "ExistingLeaseType",
     "level": "bronze",
-    "path": "/Property",
     "enum": [
       "Absolute Net",
       "CPI Adjustment",
@@ -2936,41 +3299,46 @@
     ]
   },
   "UnitsFurnished": {
+    "definition": "Are the units furnished?  i.e. All Units, Varies By Unit, None.\r\n",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "TotalActualRent": {
+    "definition": "Total actual rent currently being collected from tenants of the income property.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "bronze",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "bronze"
   },
   "RentControlYN": {
+    "definition": "Is the property in a rent control area?",
     "type": "boolean",
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "NumberOfUnitsTotal": {
+    "definition": "Total number of units included in the income property, occupied or unoccupied.",
     "type": "number",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 3,
+    "level": "core"
   },
   "NumberOfBuildings": {
+    "definition": "Total number of separate buildings included in the income property.",
     "type": "number",
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 3,
+    "synonyms": [
+      "NumberOfUnitsBuildings"
+    ],
+    "level": "bronze"
   },
   "OwnerPays": {
+    "definition": "A list of expenses for the property paid for by the owner as opposed to the tenant (e.g. Water, Trash, Electric).",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "OwnerPays",
     "level": "bronze",
-    "path": "/Property",
     "enum": [
       "All Utilities",
       "Association Fees",
@@ -3004,12 +3372,16 @@
     ]
   },
   "TenantPays": {
+    "definition": "A list of services or items that the tenant is responsible to pay.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
+    "synonyms": [
+      "TenantExpense"
+    ],
     "lookup": "TenantPays",
     "level": "bronze",
-    "path": "/Property",
     "enum": [
       "All Utilities",
       "Association Fees",
@@ -3043,131 +3415,155 @@
     ]
   },
   "VacancyAllowance": {
+    "definition": "An estimate of the amount of rent that may be foregone because of unoccupied units.",
     "type": "number",
-    "level": "bronze",
-    "path": "/Property"
+    "maxLength": 9,
+    "level": "bronze"
   },
   "VacancyAllowanceRate": {
+    "definition": "An estimate of the percent of rent that may be foregone because of unoccupied units.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "bronze",
-    "path": "/Property"
+    "maxLength": 5,
+    "maxPrecision": 2,
+    "level": "bronze"
   },
   "CableTvExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "ElectricExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "GardnerExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "FurnitureReplacementExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "FuelExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "InsuranceExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "OtherExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "LicensesExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "MaintenanceExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "NewTaxesExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "PestControlExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "PoolExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "SuppliesExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "TrashExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "WaterSewerExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "WorkmansCompensationExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "ProfessionalManagementExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.  This is for a management company.  Use ManagerExpense for a individual manager.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "synonyms": [
+      "ManagementCompanyExpense"
+    ],
+    "level": "silver"
   },
   "ManagerExpense": {
+    "definition": "The annual expense that is not paid directly by the tenant and is included in the Operating Expense calculations.  This is for an individual manager.  Use ProfessionalManagementExpense for a management company.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "FinancialDataSource": {
+    "definition": "The source of the Rental information. For example Accountant, Owner, etc.",
     "type": [
       "string"
     ],
+    "maxLength": 75,
     "lookup": "FinancialDataSource",
     "level": "bronze",
-    "path": "/Property",
     "enum": [
       "Accountant",
       "Owner",
@@ -3175,13 +3571,13 @@
     ]
   },
   "RentIncludes": {
+    "definition": "A list of services or items that the tenant is not responsible to pay.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "RentIncludes",
     "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "All Utilities",
       "Cable TV",
@@ -3198,11 +3594,11 @@
     ]
   },
   "Furnished": {
+    "definition": "The property being leased is furnished, unfurnished or partially furnished.",
     "type": "string",
     "maxLength": 50,
     "lookup": "Furnished",
     "level": "bronze",
-    "path": "/Property",
     "enum": [
       "Furnished",
       "Partially",
@@ -3210,19 +3606,22 @@
     ]
   },
   "BusinessName": {
+    "definition": "Name of the business being sold.",
     "type": "string",
     "maxLength": 255,
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "BusinessType": {
+    "definition": "The type of business being sold.  Retail, Wholesale, Grocery, Food & Bev, etc.…",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
+    "synonyms": [
+      "PropertySubType"
+    ],
     "lookup": "BusinessType",
     "level": "core",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Accounting",
       "Administrative and Support",
@@ -3336,11 +3735,11 @@
     ]
   },
   "OwnershipType": {
+    "definition": "Current type of ownership of the business being sold.  i.e. Corporation, LLC, Sole P, Partnership, etc.,",
     "type": "string",
     "maxLength": 50,
     "lookup": "OwnershipType",
     "level": "bronze",
-    "path": "/Property",
     "enum": [
       "Corporation",
       "LLC",
@@ -3349,12 +3748,13 @@
     ]
   },
   "SpecialLicenses": {
+    "definition": "Special licenses required/used by the business being sold.  i.e. Beer/Wine, Class H, Professional, Gambling, None.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "SpecialLicenses",
     "level": "bronze",
-    "path": "/Property",
     "enum": [
       "Beer/Wine",
       "Class H",
@@ -3372,27 +3772,30 @@
     ]
   },
   "NumberOfFullTimeEmployees": {
+    "definition": "The current number of individuals employed by the business on a full-time basis.",
     "type": "number",
-    "level": "bronze",
-    "path": "/Property"
+    "maxLength": 10,
+    "level": "bronze"
   },
   "NumberOfPartTimeEmployees": {
+    "definition": "The current number of individuals employed by the business on a part-time basis.",
     "type": "number",
-    "level": "bronze",
-    "path": "/Property"
+    "maxLength": 10,
+    "level": "bronze"
   },
   "LeaseAmount": {
+    "definition": "The amount of any lease the business pays for it's current location.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "bronze",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "bronze"
   },
   "LeaseAmountFrequency": {
+    "definition": "The frequency of the LeaseAmount is paid.  Monthly, weekly, annual, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "FeeFrequency",
     "level": "bronze",
-    "path": "/Property",
     "enum": [
       "Daily",
       "Weekly",
@@ -3408,65 +3811,70 @@
     ]
   },
   "LeaseExpiration": {
+    "definition": "The expiration date of the lease for the business' current location.",
     "type": "date",
-    "level": "bronze",
-    "path": "/Property"
+    "maxLength": 10,
+    "level": "bronze"
   },
   "LeaseRenewalOptionYN": {
+    "definition": "Is there an option to renew the lease at the business' current location.",
     "type": "boolean",
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "LeaseAssignableYN": {
+    "definition": "Can the lease at the business' current location be assigned to another party.",
     "type": "boolean",
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "HoursDaysOfOperation": {
+    "definition": "A simplified enumerated list of the days and hours of operation of the business being sold.  i.e. Open 24 Hours or Open 7 Days.  For more detailed descriptions use the HoursDaysofOperationDescription field.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "HoursDaysOfOperation",
-    "level": "silver",
-    "path": "/Property"
+    "level": "silver"
   },
   "HoursDaysofOperationDescription": {
+    "definition": "A detailed description of the hours and days the business being sold is open for business.  For a specific list of simplified times the business is open, use the HoursDaysofOperation enumerated field.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Property"
+    "level": "silver"
   },
   "YearEstablished": {
+    "definition": "The year the business being sold was established.",
     "type": "number",
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 4,
+    "level": "silver"
   },
   "SeatingCapacity": {
+    "definition": "The seating capacity of the business being sold.",
     "type": "number",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 10,
+    "level": "silver"
   },
   "YearsCurrentOwner": {
+    "definition": "The number of years the current owner has had possession of the business.",
     "type": "number",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 4,
+    "level": "silver"
   },
   "LaborInformation": {
+    "definition": "Information about labor laws that are applicable to the business being sold. i.e. Union, Non-Union, Employee License Required.",
     "type": [
       "string"
     ],
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "silver"
   },
   "Utilities": {
+    "definition": "A list of the utilities for the property being sold/leased.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "Utilities",
     "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Cable Available",
       "Cable Connected",
@@ -3494,13 +3902,13 @@
     ]
   },
   "Electric": {
+    "definition": "A list of electric-service related features of the property (e.g. 110 Volt, 3 Phase, 220 Volt, RV Hookup). Note: the previous \"Electric\" field was renamed to DistanceToElectricComments",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "Electric",
     "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "220 Volts For Spa",
       "220 Volts in Garage",
@@ -3529,27 +3937,29 @@
     ]
   },
   "Gas": {
+    "definition": "A list of gas-service related features of the property (e.g. Natural Gas, Private LP Tank, None). Note: the previous \"Gas\" field was renamed to DistanceToGasComments",
     "type": [
       "string"
     ],
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "bronze"
   },
   "Telephone": {
+    "definition": "A list of telephone-service related features of the property (e.g. Installed, Public, Available). Note: the previous \"Telephone\" field was renamed to DistanceToPhoneServiceComments",
     "type": [
       "string"
     ],
-    "level": "bronze",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "bronze"
   },
   "PowerProductionType": {
+    "definition": "This field is a list of the types of power production system(s) available on the property. The key characteristics of the system are expected to appear as the \"[type]\" in the related power production fields in a flattened implementation (RETS 1.x only) of the power production fields.  A relational implementation of power production must omit the type from the field name and use PowerProductionType to create a vertical representation of the various types of power production available.  \r\n\r\n**Note that PV Solar is the only type of power production currently justified in multiple markets and thus shown. Up and coming renewables that could be added in the future depending on uptake: Wind, Geothermal, Thin Film Solar.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "PowerProductionType",
     "level": "silver",
-    "path": "/Property",
     "repeating": true,
     "enum": [
       "Photovoltaics",
@@ -3566,25 +3976,27 @@
         ]
       },
       "Size": {
+        "definition": "The “capacity” of a renewables system. Size is measured in kilowatts (kW) DC (referring to direct current).  A kW indicates how much power the system can produce under standard conditions, like the size of a car engine. Renewables systems are sized when they are installed to cover all or a portion of the power needs of the property. Therefore, a system designed to produce 50% of the power needs will be sized smaller than a system on the exact same property designed to produce 100%. Size may be influenced by available space at the property, orientation, landscaping, etc.  ",
         "type": "number",
-        "maxPrecision": "2",
-        "level": "silver",
-        "path": "/Property"
+        "maxLength": 5,
+        "maxPrecision": 2,
+        "level": "silver"
       }
     }
   ],
   "PowerProduction[Type] Annual": {
+    "definition": "The most important metric of a renewables system is the amount of power it produces per year.  This number can be actual or estimated. Annual production for systems producing electricity like wind or solar are measured in kilowatt hours (kWh) per year.  A kWh is like a measure of the distance traveled per hour for a car – how far did it go over a certain period of time. Annual production is influenced by the size of the system, the conditions (How shady are the trees? How many cloudy days?, and the installation.  Sellers typically have access to software that provides historical production totals.  ",
     "type": "number",
+    "maxLength": 6,
     "level": "silver",
-    "path": "/Property",
     "repeating": true
   },
   "PowerProduction[Type]AnnualStatus ": {
+    "definition": "The most important metric of a renewables system is the amount of power it produces per year.  This number can be actual or estimated, or a combination if less than 12 months of actual data is available (any missing months of actual data is extrapolated).  This field allows the status of the number shown in the PowerProducationAnnual[Type] to be clarified.",
     "type": "string",
     "maxLength": 25,
     "lookup": "PowerProductionAnnualStatus",
     "level": "silver",
-    "path": "/Property",
     "repeating": true,
     "enum": [
       "Estimated",
@@ -3593,37 +4005,40 @@
     ]
   },
   "PowerProduction[Type]YearInstall": {
+    "definition": "The year a renewables system was installed.  Ideally this should be the year the system was interconnected with the grid and began producing power.  Renewables systems have a limited lifespan and year installed helps buyers and appraisers determine remaining useful life of the system.",
     "type": "number",
+    "maxLength": 4,
     "level": "silver",
-    "path": "/Property",
     "repeating": true
   },
   "IrrigationWaterRightsYN": {
+    "definition": "Does the property include water rights for irrigation?  A Boolean or Yes / No field.",
     "type": "boolean",
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "IrrigationWaterRightsAcres": {
+    "definition": "The number of acres allowed under the property's water rights.",
     "type": "number",
-    "maxPrecision": "4",
-    "level": "bronze",
-    "path": "/Property"
+    "maxLength": 16,
+    "maxPrecision": 4,
+    "level": "bronze"
   },
   "IrrigationSource": {
+    "definition": "The source which the property receives its water for irrigation.",
     "type": [
       "string"
     ],
-    "level": "bronze",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "bronze"
   },
   "WaterSource": {
+    "definition": "A list of the source(s) of water for the property",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "WaterSource",
     "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Cistern",
       "None",
@@ -3637,62 +4052,64 @@
     ]
   },
   "DistanceToWaterComments": {
+    "definition": "If the property does not currently have water utility, is service available and if so, what is the distance.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Property"
+    "level": "silver"
   },
   "DistanceToWaterNumeric": {
+    "definition": "Numeric distance from the property to the water utility.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property"
+    "maxLength": 16,
+    "level": "platinum"
   },
   "DistanceToWaterUnits": {
+    "definition": "A pick list of the unit linear measurement.  i.e. feed, meters, yards, kilometers, miles, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "LinearUnits",
     "level": "platinum",
-    "path": "/Property",
     "enum": [
       "Feet",
       "Meters"
     ]
   },
   "ElectricOnPropertyYN": {
+    "definition": "Does the property currently have electrical utility available on the property.",
     "type": "boolean",
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "DistanceToElectricComments": {
+    "definition": "If the property does not currently have electrical utility, is service available and if so, what is the distance.",
     "type": "string",
     "maxLength": 255,
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "DistanceToElectricNumeric": {
+    "definition": "Numeric distance from the property to the electrical utility.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property"
+    "maxLength": 16,
+    "level": "platinum"
   },
   "DistanceToElectricUnits": {
+    "definition": "A pick list of the unit linear measurement.  i.e. feed, meters, yards, kilometers, miles, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "LinearUnits",
     "level": "platinum",
-    "path": "/Property",
     "enum": [
       "Feet",
       "Meters"
     ]
   },
   "Sewer": {
+    "definition": "A list describing the sewer or septic features of the property.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "Sewer",
     "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Aerobic Septic",
       "Cesspool",
@@ -3712,306 +4129,321 @@
     ]
   },
   "DistanceToSewerComments": {
+    "definition": "If the property does not currently have sewer or septic, is sewer service available and if so, what is the distance.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Property"
+    "level": "silver"
   },
   "DistanceToSewerNumeric": {
+    "definition": "Numeric distance from the property to the sewer utility.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property"
+    "maxLength": 16,
+    "level": "platinum"
   },
   "DistanceToSewerUnits": {
+    "definition": "A pick list of the unit linear measurement.  i.e. feed, meters, yards, kilometers, miles, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "LinearUnits",
     "level": "platinum",
-    "path": "/Property",
     "enum": [
       "Feet",
       "Meters"
     ]
   },
   "DistanceToGasComments": {
+    "definition": "If the property does not currently have natural gas utility, is service available and if so, what is the distance.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Property"
+    "level": "silver"
   },
   "DistanceToGasNumeric": {
+    "definition": "Numeric distance from the property to the gas utility.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property"
+    "maxLength": 16,
+    "level": "platinum"
   },
   "DistanceToGasUnits": {
+    "definition": "A pick list of the unit linear measurement.  i.e. feed, meters, yards, kilometers, miles, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "LinearUnits",
     "level": "platinum",
-    "path": "/Property",
     "enum": [
       "Feet",
       "Meters"
     ]
   },
   "DistanceToPhoneServiceComments": {
+    "definition": "If the property does not currently have phone service, is service available and if so, what is the distance.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Property"
+    "level": "silver"
   },
   "DistanceToPhoneServiceNumeric": {
+    "definition": "Numeric distance from the property to the phone utility.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property"
+    "maxLength": 16,
+    "level": "platinum"
   },
   "DistanceToPhoneServiceUnits": {
+    "definition": "A pick list of the unit linear measurement.  i.e. feed, meters, yards, kilometers, miles, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "LinearUnits",
     "level": "platinum",
-    "path": "/Property",
     "enum": [
       "Feet",
       "Meters"
     ]
   },
   "DistanceToStreetComments": {
+    "definition": "If the property does not have a maintained road or street adjacent to the lot, what are the conditions of access and distance to a maintained road.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Property"
+    "level": "silver"
   },
   "DistanceToStreetNumeric": {
+    "definition": "Numeric distance from the property to the street.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property"
+    "maxLength": 16,
+    "level": "platinum"
   },
   "DistanceToStreetUnits": {
+    "definition": "A pick list of the unit linear measurement.  i.e. feed, meters, yards, kilometers, miles, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "LinearUnits",
     "level": "platinum",
-    "path": "/Property",
     "enum": [
       "Feet",
       "Meters"
     ]
   },
   "DistanceToSchoolsComments": {
+    "definition": "A textual description of the distance to local schools.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Property"
+    "level": "silver"
   },
   "DistanceToSchoolsNumeric": {
+    "definition": "Numeric distance from the property to the nearest school.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property"
+    "maxLength": 16,
+    "level": "platinum"
   },
   "DistanceToSchoolsUnits": {
+    "definition": "A pick list of the unit linear measurement.  i.e. feed, meters, yards, kilometers, miles, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "LinearUnits",
     "level": "platinum",
-    "path": "/Property",
     "enum": [
       "Feet",
       "Meters"
     ]
   },
   "DistanceToShoppingComments": {
+    "definition": "A description of the distance to primary shopping sources such as groceries, gasoline, clothing or department stores.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Property"
+    "level": "silver"
   },
   "DistanceToShoppingNumeric": {
+    "definition": "Numeric distance from the property to the nearest shopping.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property"
+    "maxLength": 16,
+    "level": "platinum"
   },
   "DistanceToShoppingUnits": {
+    "definition": "A pick list of the unit linear measurement.  i.e. feed, meters, yards, kilometers, miles, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "LinearUnits",
     "level": "platinum",
-    "path": "/Property",
     "enum": [
       "Feet",
       "Meters"
     ]
   },
   "DistanceToPlaceofWorshipComments": {
+    "definition": "A textual description of the distance to local places of worship.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Property"
+    "level": "silver"
   },
   "DistanceToPlaceofWorshipNumeric": {
+    "definition": "Numeric distance from the property to the nearest place of worship.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property"
+    "maxLength": 16,
+    "level": "platinum"
   },
   "DistanceToPlaceofWorshipUnits": {
+    "definition": "A pick list of the unit linear measurement.  i.e. feed, meters, yards, kilometers, miles, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "LinearUnits",
     "level": "platinum",
-    "path": "/Property",
     "enum": [
       "Feet",
       "Meters"
     ]
   },
   "DistanceToBusComments": {
+    "definition": "A textual description of the distance to local bus stops.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Property"
+    "level": "silver"
   },
   "DistanceToBusNumeric": {
+    "definition": "Numeric distance from the property to the nearest bus stop.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property"
+    "maxLength": 16,
+    "level": "platinum"
   },
   "DistanceToBusUnits": {
+    "definition": "A pick list of the unit linear measurement.  i.e. feed, meters, yards, kilometers, miles, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "LinearUnits",
     "level": "platinum",
-    "path": "/Property",
     "enum": [
       "Feet",
       "Meters"
     ]
   },
   "DistanceToSchoolBusComments": {
+    "definition": "Distance from the property to the nearest school bus pickup point.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Property"
+    "level": "silver"
   },
   "DistanceToSchoolBusNumeric": {
+    "definition": "Numeric distance from the property to the nearest school bus pickup point.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property"
+    "maxLength": 16,
+    "level": "platinum"
   },
   "DistanceToSchoolBusUnits": {
+    "definition": "A pick list of the unit linear measurement.  i.e. feed, meters, yards, kilometers, miles, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "LinearUnits",
     "level": "platinum",
-    "path": "/Property",
     "enum": [
       "Feet",
       "Meters"
     ]
   },
   "DistanceToFreewayComments": {
+    "definition": "A textual description of the distance to freeways.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Property"
+    "level": "silver"
   },
   "DistanceToFreewayNumeric": {
+    "definition": "Numeric distance from the property to the nearest freeway.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Property"
+    "maxLength": 16,
+    "level": "platinum"
   },
   "DistanceToFreewayUnits": {
+    "definition": "A pick list of the unit linear measurement.  i.e. feed, meters, yards, kilometers, miles, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "LinearUnits",
     "level": "platinum",
-    "path": "/Property",
     "enum": [
       "Feet",
       "Meters"
     ]
   },
   "CropsIncludedYN": {
+    "definition": "Are crops included in the sale of the property.",
     "type": "boolean",
-    "level": "gold",
-    "path": "/Property"
+    "level": "gold"
   },
   "GrazingPermitsBlmYN": {
+    "definition": "Specifies whether or not the property owner has grazing permits from the Bureau of Land Management.",
     "type": "boolean",
-    "level": "gold",
-    "path": "/Property"
+    "level": "gold"
   },
   "GrazingPermitsForestServiceYN": {
+    "definition": "Specifies whether or not the property owner has grazing permits from the Forestry Service.",
     "type": "boolean",
-    "level": "gold",
-    "path": "/Property"
+    "level": "gold"
   },
   "GrazingPermitsPrivateYN": {
+    "definition": "Specifies whether or not the property owner has private grazing permits.",
     "type": "boolean",
-    "level": "gold",
-    "path": "/Property"
+    "level": "gold"
   },
   "CultivatedArea": {
+    "definition": "Measurement or percentage of the property that has been cultivated.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "gold",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "gold"
   },
   "PastureArea": {
+    "definition": "Measurement or percentage of the property that has been allocated as pasture or grazing area.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "gold",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "gold"
   },
   "RangeArea": {
+    "definition": "Measurement or percentage of the property that has been allocated as range.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "gold",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "gold"
   },
   "WoodedArea": {
+    "definition": "Measurement or percentage of the property that is wooded or forest.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "gold",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "gold"
   },
   "Vegetation": {
+    "definition": "A list of the type(s) of vegetation on the property.  Note that this is not for farm crops, but more residential type vegetation.\r\n",
     "type": [
       "string"
     ],
-    "level": "gold",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "gold"
   },
   "Fencing": {
+    "definition": "A list of types of fencing found at the property being sold.",
     "type": [
       "string"
     ],
-    "level": "gold",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "gold"
   },
   "FarmCreditServiceInclYN": {
+    "definition": "Specifies whether or not Farm Credit Service shares are included in the price of the property.",
     "type": "boolean",
-    "level": "gold",
-    "path": "/Property"
+    "level": "gold"
   },
   "FarmLandAreaUnits": {
+    "definition": "A pick list of the unit of measurement for the area.  i.e. Square Feet, Square Meters, Acres, etc.  This field applies to all farm area fields (Cultivated, Pasture, Range, Wooded)",
     "type": "string",
     "maxLength": 25,
     "lookup": "AreaUnits",
     "level": "gold",
-    "path": "/Property",
     "enum": [
       "Square Feet",
       "Square Meters"
     ]
   },
   "FarmLandAreaSource": {
+    "definition": "The source of the measurements. This may be a pick list of options showing the source of the measurement. i.e. Agent, Assessor, Estimate, etc. This field applies to all farm area fields (Cultivated, Pasture, Range, Wooded)",
     "type": "string",
     "maxLength": 50,
     "lookup": "AreaSource",
     "level": "gold",
-    "path": "/Property",
     "enum": [
       "Appraiser",
       "Assessor",
@@ -4025,120 +4457,151 @@
     ]
   },
   "BedroomsTotal": {
+    "definition": "The total number of bedrooms in the dwelling.",
     "type": "number",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 3,
+    "synonyms": [
+      "BedroomsTotal"
+    ],
+    "level": "core"
   },
   "BedroomsPossible": {
+    "definition": "The sum of BedroomsTotal plus other rooms that may be used as a bedroom but are not defined as bedroom per local policy.",
     "type": "number",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 3,
+    "synonyms": [
+      "BedroomsTotal"
+    ],
+    "level": "silver"
   },
   "MainLevelBedrooms": {
+    "definition": "The number of bedrooms located on the main or entry level of the property.",
     "type": "number",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 3,
+    "level": "silver"
   },
   "BathroomsTotalInteger": {
+    "definition": "The simple sum of the number of bathrooms.  For example for a property with two Full Bathrooms and one Half Bathroom, the Bathrooms Total Integer will be 3.  To express this example as 2.5, use the BathroomsTotalDecimal field.  To express this example as 2.1, use the BathroomsTotalNotational.",
     "type": "number",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 3,
+    "level": "core"
   },
   "BathroomsFull": {
+    "definition": "A room containing all 4 of the 4 elements constituting a bath, which are; Toilet, Sink, Bathtub or Shower Head.  A Full Bath will typically contain four elements; Sink, Toilet, Tub and Shower Head (in tub or stall).  However, some may considered a Sink, Toilet and Tub (without a shower) a Full Bath, others consider this to be a Three Quarter Bath.  In the event that BathroomsThreeQuarter is not in use, this field may represent the sum of all Full and Three Quarter bathrooms.",
     "type": "number",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 3,
+    "synonyms": [
+      "BathroomsFull",
+      "FullBaths"
+    ],
+    "level": "core"
   },
   "BathroomsHalf": {
+    "definition": "A room containing 2 of the 4 elements constituting a bath, which are; Toilet, Sink, Bathtub or Shower Head.  A Half Bath will typically contain a Sink and Toilet.",
     "type": "number",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 3,
+    "synonyms": [
+      "BathroomsHalf",
+      "HalfBaths"
+    ],
+    "level": "core"
   },
   "BathroomsThreeQuarter": {
+    "definition": "A room containing 3 of the 4 elements constituting a bath, which are; Toilet, Sink, Bathtub or Shower Head. A typical Three Quarter Bath will contain Sink, Toilet and Shower.  Some may considered a Sink, Toilet and Tub (without a shower) a Three Quarter Bath, others consider this to be a Full Bath.",
     "type": "number",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 3,
+    "synonyms": [
+      "BathroomsThreeQuarter",
+      "ThreeQuarterBaths"
+    ],
+    "level": "core"
   },
   "BathroomsOneQuarter": {
+    "definition": "A room containing 1 of the 4 elements constituting a bath which are; Toilet, Sink, Bathtub or Shower Head.  Examples are a vanity with a sink or a WC (Water Closet, which is a room with only a toilet).",
     "type": "number",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 3,
+    "synonyms": [
+      "BathroomsOneQuarter",
+      "QuarterBaths"
+    ],
+    "level": "core"
   },
   "BathroomsPartial": {
+    "definition": "The number of partial bathrooms in the property being sold/leased.  When used in combination with the BathroomsFull field, this replaces (or is the sum of) all Half and One Quarter bathrooms; and in the event BathroomsThreeQuarter is not used, BathroomsFull replaces (or is the sum of) all Full and Three Quarter baths.  This field should not be used in combination with the BathroomsOneQuarter or the BathroomsHalf.",
     "type": "number",
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 3,
+    "level": "silver"
   },
   "MainLevelBathrooms": {
+    "definition": "The number of bathrooms located on the main or entry level of the property.",
     "type": "number",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 3,
+    "level": "silver"
   },
   "LivingArea": {
+    "definition": "The total livable area within the structure.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "core"
   },
   "LivingAreaUnits": {
+    "definition": "A pick list of the unit of measurement for the area.  i.e. Square Feet, Square Meters, Acres, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "AreaUnits",
     "level": "core",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Square Feet",
       "Square Meters"
     ]
   },
   "PropertyAttachedYN": {
+    "definition": "A flag indicating that the primary structure is attached to another structure that is not included in the sale.  i.e. one unit of a duplex. This flag may be T/F, Y/N or a list of attached or detached. As with all flags, the field may be null.  In some systems this information may be part of the Property Sub Type.",
     "type": "boolean",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "synonyms": [
+      "StructureAttachedYN"
+    ],
+    "level": "core"
   },
   "GarageYN": {
+    "definition": "A flag indicating that the listing has a garage. This flag may be T/F, Y/N or other true, false or unknown indicator. As with all flags, the field may be null.",
     "type": "boolean",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "core"
   },
   "GarageSpaces": {
+    "definition": "The number of spaces in the garage(s).",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "core"
   },
   "StoriesTotal": {
+    "definition": "The total number of floors in the building.  In the case of multi-dwelling structures, this is the entire structure and not the individual dwelling being sold.",
     "type": "number",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 3,
+    "synonyms": [
+      "StoriesBuildingTotal"
+    ],
+    "level": "core"
   },
   "Stories": {
+    "definition": "The number of floors in the property being sold.",
     "type": "number",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 2,
+    "synonyms": [
+      "Floors"
+    ],
+    "level": "core"
   },
   "Levels": {
+    "definition": "The number of levels in the property being sold.  For example, One Level, Two Levels, Split Level, Three or More Levels, Multi Level, Loft.    A discreet horizontal plane of interior living space (excluding basements).",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "Levels",
     "level": "core",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "One",
       "Two",
@@ -4147,51 +4610,53 @@
     ]
   },
   "YearBuilt": {
+    "definition": "The year that an occupancy permit is first granted for the house or other local measure of initial habitability of the build. The type definition permits an empty value with an attribute noting that it is an unknown date or that the building is new construction. While constraints have not been applied, convention at the time of adoption has this as a four (4) digit year value.",
     "type": "number",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 4,
+    "level": "core"
   },
   "MobileLength": {
+    "definition": "Length of the mobile/manufactured home.",
     "type": "number",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 4,
+    "level": "core"
   },
   "MobileWidth": {
+    "definition": "Width of the mobile/manufactured home.",
     "type": "number",
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 4,
+    "level": "core"
   },
   "Make": {
+    "definition": "Make of the mobile or manufactured home.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "core"
   },
   "Model": {
+    "definition": "Model of the mobile or manufactured home.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "core"
   },
   "ParcelNumber": {
+    "definition": "A number used to uniquely identify a parcel or lot.  This number is typically issued by the county or county assessor.  The AP number format varies from county to county.  It is recommended that all Parcel Numbers be transmitted without dashes or hyphens.",
     "type": "string",
     "maxLength": 50,
-    "level": "core",
-    "payloads": "IDX",
-    "path": "/Property"
+    "synonyms": [
+      "APN",
+      "AssessorsParcelNumber",
+      "TaxID",
+      "AssessorNumber"
+    ],
+    "level": "core"
   },
   "LivingAreaSource": {
+    "definition": "The source of the measurements. This is a pick list of options showing the source of the measurement. i.e. Agent, Assessor, Estimate, etc.",
     "type": "string",
     "maxLength": 50,
     "lookup": "AreaSource",
     "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Appraiser",
       "Assessor",
@@ -4205,17 +4670,18 @@
     ]
   },
   "AboveGradeFinishedArea": {
+    "definition": "Finished area within the structure that is at or above the surface of the ground.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "AboveGradeFinishedAreaSource": {
+    "definition": "The source of the measurements. This is a pick list of options showing the source of the measurement. i.e. Agent, Assessor, Estimate, etc.",
     "type": "string",
     "maxLength": 50,
     "lookup": "AreaSource",
     "level": "silver",
-    "path": "/Property",
     "enum": [
       "Appraiser",
       "Assessor",
@@ -4229,28 +4695,29 @@
     ]
   },
   "AboveGradeFinishedAreaUnits": {
+    "definition": "A pick list of the unit of measurement for the area.  i.e. Square Feet, Square Meters, Acres, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "AreaUnits",
     "level": "silver",
-    "path": "/Property",
     "enum": [
       "Square Feet",
       "Square Meters"
     ]
   },
   "BelowGradeFinishedArea": {
+    "definition": "Finished area within the structure that is below ground.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "BelowGradeFinishedAreaSource": {
+    "definition": "The source of the measurements. This is a pick list of options showing the source of the measurement. i.e. Agent, Assessor, Estimate, etc.",
     "type": "string",
     "maxLength": 50,
     "lookup": "AreaSource",
     "level": "silver",
-    "path": "/Property",
     "enum": [
       "Appraiser",
       "Assessor",
@@ -4264,29 +4731,29 @@
     ]
   },
   "BelowGradeFinishedAreaUnits": {
+    "definition": "A pick list of the unit of measurement for the area.  i.e. Square Feet, Square Meters, Acres, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "AreaUnits",
     "level": "silver",
-    "path": "/Property",
     "enum": [
       "Square Feet",
       "Square Meters"
     ]
   },
   "BuildingAreaTotal": {
+    "definition": "Total area of the structure. Includes both finished and unfinished areas.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "BuildingAreaSource": {
+    "definition": "The source of the measurements. This is a pick list of options showing the source of the measurement. i.e. Agent, Assessor, Estimate, etc.",
     "type": "string",
     "maxLength": 50,
     "lookup": "AreaSource",
     "level": "silver",
-    "path": "/Property",
     "enum": [
       "Appraiser",
       "Assessor",
@@ -4300,41 +4767,42 @@
     ]
   },
   "BuildingAreaUnits": {
+    "definition": "A pick list of the unit of measurement for the area.  i.e. Square Feet, Square Meters, Acres, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "AreaUnits",
     "level": "silver",
-    "path": "/Property",
     "enum": [
       "Square Feet",
       "Square Meters"
     ]
   },
   "LeasableArea": {
+    "definition": "The area that may be leased within the commercial property.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "LeasableAreaUnits": {
+    "definition": "A pick list of the unit of measurement for the area.  i.e. Square Feet, Square Meters, Acres, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "AreaUnits",
     "level": "silver",
-    "path": "/Property",
     "enum": [
       "Square Feet",
       "Square Meters"
     ]
   },
   "CommonWalls": {
+    "definition": "A multi select list with options like 1 Common Wall, 2 Common Walls, No Common Walls, No One Above, No One Below.  Implementation should include rules preventing illogical selection combinations and to ensure consistency with the Property Attached Y/N field.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "CommonWalls",
     "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "1 Common Wall",
       "2+ Common Walls",
@@ -4345,107 +4813,114 @@
     ]
   },
   "FoundationArea": {
+    "definition": "The area or dimensions of the footprint of the structure on the lot.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "AttachedGarageYN": {
+    "definition": "A flag indicating that the garage attached to the dwelling.",
     "type": "boolean",
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "silver"
   },
   "CarportSpaces": {
+    "definition": "The number of carport spaces included in the sale.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "CarportYN": {
+    "definition": "A flag indicating that the listing has a car port. This flag may be T/F, Y/N or other true, false or unknown indicator. As with all flags, the field may be null.",
     "type": "boolean",
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "silver"
   },
   "OpenParkingYN": {
+    "definition": "A flag indicating that any parking spaces associated with the property are not covered by a roof.",
     "type": "boolean",
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "silver"
   },
   "OpenParkingSpaces": {
+    "definition": "The number of open or uncovered parking spaces included in the sale.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "synonyms": [
+      "UncoveredParking"
+    ],
+    "level": "bronze"
   },
   "CoveredSpaces": {
+    "definition": "The total number of garage and carport spaces.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "bronze"
   },
   "ParkingFeatures": {
+    "definition": "A list of features or description of the parking included in the sale/lease.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "OtherParking": {
+    "definition": "Other types of parking available to, or part of, the property.",
     "type": "string",
     "maxLength": 1024,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "silver"
   },
   "ParkingTotal": {
+    "definition": "The total number of parking spaces included in the sale.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "RVParkingDimensions": {
+    "definition": "The dimensions of the RV parking area minimally represented as length and width (i.e. 25 x 18) or a measurement of all sides of the polygon representing the usable RV parking space.  i.e. 33 x 15 x 12 x 60.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Property"
+    "level": "silver"
   },
   "EntryLocation": {
+    "definition": "A description of the main entry way to the property.  i.e. Elevator, Ground Level w/ Steps, Ground Level w/o Steps, Mid Level, Top Level, etc.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Property"
+    "synonyms": [
+      "Entry Description"
+    ],
+    "level": "silver"
   },
   "EntryLevel": {
+    "definition": "A numeric field that describes the level within the structure, SFR or a unit in a building, where the main entry to the dwelling is located.  When a unit has one floor it is implicit that this is also the level of the unit itself.",
     "type": "number",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 4,
+    "synonyms": [
+      "Unit Floor Number"
+    ],
+    "level": "silver"
   },
   "YearBuiltEffective": {
+    "definition": "The year a major rebuild/renovated of the structure occurred.",
     "type": "number",
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 4,
+    "level": "bronze"
   },
   "YearBuiltDetails": {
+    "definition": "A description of the details behind the year the structure was built.",
     "type": "string",
     "maxLength": 1024,
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "YearBuiltSource": {
+    "definition": "Add a list of sources of the year built.  i.e. Appraiser, Assessor, Builder, Estimated, etc.,",
     "type": "string",
     "maxLength": 60,
     "lookup": "YearBuiltSource",
     "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Appraiser",
       "Assessor",
@@ -4458,19 +4933,23 @@
     ]
   },
   "NewConstructionYN": {
+    "definition": "Is the property newly constructed and has not been previously occupied?",
     "type": "boolean",
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "silver"
   },
   "GreenBuildingVerificationType": {
+    "definition": "The name of the verification or certification awarded to a new or pre-existing residential or commercial structure. For example: LEED, Energy Star, ICC-700.  In cases where more than one certification have been awarded, leverage multiple iterations of the green verification fields via the repeating element method.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
+    "synonyms": [
+      "GreenBuildingCertification",
+      "GreenBuildingVerification",
+      "GreenBuildingRating"
+    ],
     "lookup": "GreenBuildingVerificationType",
     "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property",
     "repeating": true,
     "enum": [
       "ENERGY STAR Certified Homes",
@@ -4517,59 +4996,85 @@
         ]
       },
       "Body": {
+        "definition": "The name of the body or group providing the verification/certification/rating named in the GreenBuildingVerificationType field.  There is almost always a direct correlation between bodies and programs. This is a repeating element.  If desired replace [Type] with the name of the certification from the GreenBuildingVerificationType list.",
         "type": "string",
         "maxLength": 50,
-        "level": "silver",
-        "payloads": "IDX",
-        "path": "/Property"
+        "synonyms": [
+          "GreenCertifyingBudy",
+          "GreenRatingBody"
+        ],
+        "level": "silver"
       },
       "Year": {
+        "definition": "The year the certification or verification was awarded.  This is a repeating element.  If desired replace [Type] with the name of the certification from the GreenBuildingVerificationType list.",
         "type": "number",
-        "level": "silver",
-        "payloads": "IDX",
-        "path": "/Property"
+        "maxLength": 4,
+        "synonyms": [
+          "GreenYearCertified",
+          "GreenRatingYear"
+        ],
+        "level": "silver"
       },
       "Version": {
+        "definition": "The version of the certification or verification that was awarded.  Some rating programs have a year, a version, or possibly both.  This is a repeating element.  If desired replace [Type] with the name of the certification from the GreenBuildingVerificationType list.",
         "type": "string",
         "maxLength": 25,
-        "level": "silver",
-        "payloads": "IDX",
-        "path": "/Property"
+        "synonyms": [
+          "GreenRatingVersion",
+          "GreenCertificationVersion"
+        ],
+        "level": "silver"
       },
       "Rating": {
+        "definition": "Many verifications or certifications have a rating system that provides an indication of the structure's level of energy efficiency.  When expressed in a numeric value, please use the GreenVerificationMetric field. Verifications and Certifications can also be a name, such as Gold or Silver, which is the purpose of this field. This is a repeating element.  If desired replace [Type] with the name of the certification from the GreenBuildingVerificationType list.",
         "type": "string",
         "maxLength": 50,
-        "level": "silver",
-        "payloads": "IDX",
-        "path": "/Property"
+        "synonyms": [
+          "GreenCertificationRating",
+          "GreenRating"
+        ],
+        "level": "silver"
       },
       "Metric": {
+        "definition": "A final score indicating the performance of energy efficiency design and measures in the home as tested by a third-party rater.  Points achieved to earn a certification in the GreenVerification[Type]Rating field do not apply to this field.  HERS Index is most common with new homes and runs with a lower number being more efficient. A net-zero home uses zero energy and has a HERS score of 0.  A home that produces more energy than it uses has a negative score.  Home Energy Score is a tool more common for existing homes and runs with a higher number being more efficient.   It takes square footage into account and caps with 10 as the highest number of points. This is a repeating element.  If desired replace [Type] with the name of the certification from the GreenBuildingVerificationType list.",
         "type": "number",
-        "level": "silver",
-        "payloads": "IDX",
-        "path": "/Property"
+        "maxLength": 3,
+        "synonyms": [
+          "GreenCertificationMetric",
+          "GreenRatingMetric"
+        ],
+        "level": "silver"
       },
       "URL": {
+        "definition": "Provides a link to the specific property’s high-performance rating or scoring details directly from and hosted by the sponsoring body of the program.   Typically provides thorough details, for example, which points where achieved and how, or in the case of a score what specifically was tested and the results. This is a repeating element.  If desired replace [Type] with the name of the certification from the GreenBuildingVerificationType list.",
         "type": "string",
         "maxLength": 8000,
-        "level": "silver",
-        "payloads": "IDX",
-        "path": "/Property"
+        "synonyms": [
+          "GreenRatingURL",
+          "GreenCertificationURL"
+        ],
+        "level": "silver"
       },
       "Status": {
+        "definition": "Many verification programs include a multi-step process that may begin with plans and specs, involve testing and/or submission of building specifications along the way and include a final verification step.  When ratings are involved it is not uncommon for the final rating to be either higher or lower than the target preliminary rating.  Sometimes the final approval is not available until after sale and occupancy.  Status indicates what the target was at the time of listing and may be updated when verification is complete.  To limit liability concerns this field reflects information that was available at the time of listing or updated later and should be confirmed by the buyer.",
         "type": "string",
         "maxLength": 25,
-        "level": "silver",
-        "payloads": "IDX",
-        "path": "/Property"
+        "synonyms": [
+          "GreenRatingStatus",
+          "GreenCertificationStatus"
+        ],
+        "level": "silver"
       },
       "Source": {
+        "definition": "The source of the green data. May address photovoltaic characteristics, or a verified score, certification, label, etc. This may be a pick list of options showing the source. i.e. Program Sponsor, Program Verifier, Public Record, Assessor,  etc.  ",
         "type": "string",
         "maxLength": 25,
+        "synonyms": [
+          "GreenRatingSource",
+          "GreenCertificationSource"
+        ],
         "lookup": "GreenVerificationSource",
         "level": "silver",
-        "payloads": "IDX",
-        "path": "/Property",
         "enum": [
           "Administrator",
           "Assessor",
@@ -4586,108 +5091,113 @@
     }
   ],
   "BuilderName": {
+    "definition": "Name of the builder of the property or builder's tract.",
     "type": "string",
     "maxLength": 50,
-    "level": "gold",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "gold"
   },
   "BuilderModel": {
+    "definition": "The builders model name or number for the property.",
     "type": "string",
     "maxLength": 50,
-    "level": "gold",
-    "path": "/Property"
+    "level": "gold"
   },
   "BuildingName": {
+    "definition": "Name of the building or business park.",
     "type": "string",
     "maxLength": 50,
-    "level": "gold",
-    "path": "/Property"
+    "level": "gold"
   },
   "BuildingFeatures": {
+    "definition": "Features or amenities of the building or business park.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "Heating": {
+    "definition": "A list describing the heating features of the property.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "HeatingYN": {
+    "definition": "The property has heating.",
     "type": "boolean",
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "platinum"
   },
   "Cooling": {
+    "definition": "A list describing the cooling or air conditioning features of the property.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "CoolingYN": {
+    "definition": "The property has cooling or Air Conditioning.",
     "type": "boolean",
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "platinum"
   },
   "InteriorFeatures": {
+    "definition": "A list of features or description of the interior of the property included in the sale/lease.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "ExteriorFeatures": {
+    "definition": "A list of features or description of the exterior of the property included in the sale/lease.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "PatioAndPorchFeatures": {
+    "definition": "A list of features or description of the patio or porch included in the sale/lease.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "ArchitecturalStyle": {
+    "definition": "A list describing the style of the structure.  For example, Victorian, Ranch, Craftsman, etc.",
     "type": [
       "string"
     ],
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "synonyms": [
+      "Style"
+    ],
+    "level": "silver"
   },
   "StructureType": {
+    "definition": "The type of structure.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "StructureType",
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "platinum"
   },
   "PropertyCondition": {
+    "definition": "A list describing the condition of the property and any structures included in the sale.",
     "type": [
       "string"
+    ],
+    "maxLength": 1024,
+    "synonyms": [
+      "StructuralCondition",
+      "Condition"
     ],
     "lookup": "PropertyCondition",
     "level": "silver",
-    "path": "/Property",
     "enum": [
       "Fixer",
       "New Construction",
@@ -4696,49 +5206,48 @@
     ]
   },
   "FireplaceFeatures": {
+    "definition": "A list of features or description of the fireplace(s) included in the sale/lease.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "FireplacesTotal": {
+    "definition": "The total number of fireplaces included in the property.",
     "type": "number",
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 3,
+    "level": "platinum"
   },
   "FireplaceYN": {
+    "definition": "Does the property include a fireplace.",
     "type": "boolean",
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "platinum"
   },
   "DoorFeatures": {
+    "definition": "A list of features or description of the doors included in the sale/lease.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "WindowFeatures": {
+    "definition": "A list of features or description of the windows included in the sale/lease.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "Roof": {
+    "definition": "A list describing the type or style of roof.  For example Spanish Tile, Composite, Shake, etc.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "Roof",
     "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Aluminum",
       "Asbestos Shingle",
@@ -4777,13 +5286,13 @@
     ]
   },
   "ConstructionMaterials": {
+    "definition": "A list of the materials that were used in the construction of the property.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "ConstructionMaterials",
     "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Adobe",
       "Aluminum Siding",
@@ -4841,13 +5350,13 @@
     ]
   },
   "FoundationDetails": {
+    "definition": "A list of the type(s) of foundation on which the property sits.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "FoundationDetails",
     "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Block",
       "Brick/Mortar",
@@ -4863,36 +5372,38 @@
     ]
   },
   "Basement": {
+    "definition": "A list of information and features about the basement.  i.e. None/Slab, Finished, Partially Finished, Crawl Space, Dirt, Outside Entrance, Radon Mitigation\r\n",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "Flooring": {
+    "definition": "A list of the type(s) of flooring found within the property.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "OtherStructures": {
+    "definition": "A list of structures other than the main dwelling.  For example, Guest House, Barn, Shed, etc.",
     "type": [
       "string"
     ],
-    "level": "gold",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "gold"
   },
   "DirectionFaces": {
+    "definition": "The compass direction that the main entrance to the building faces. For example, North, South, East, West, South-West, etc. It may also be known as the building exposure.",
     "type": "string",
     "maxLength": 25,
+    "synonyms": [
+      "BuildingExposure"
+    ],
     "lookup": "DirectionFaces",
     "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "East",
       "North",
@@ -4905,58 +5416,63 @@
     ]
   },
   "OtherEquipment": {
+    "definition": "A list of other equipment that will be included in the sale of the property.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "Appliances": {
+    "definition": "A list of the appliances that will be included in the sale/lease of the property.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "LaundryFeatures": {
+    "definition": "Add this pick list of features and locations where the laundry is located in the property being sold.  i.e. Gas Dryer Hookup, In Kitchen, In Garage, etc.  CRMLS sees over 50% utilization of this field which has a dozen enumerations making it too long to fold into other fields such as rooms or Interior Features.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "SecurityFeatures": {
+    "definition": "A list describing the security features included in the sale/lease.",
     "type": [
       "string"
     ],
-    "level": "platinum",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "platinum"
   },
   "NumberOfSeparateElectricMeters": {
+    "definition": "Total number of separate meters on the property.",
     "type": "number",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 3,
+    "level": "silver"
   },
   "NumberOfSeparateGasMeters": {
+    "definition": "Total number of separate meters on the property.",
     "type": "number",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 3,
+    "level": "silver"
   },
   "NumberOfSeparateWaterMeters": {
+    "definition": "Total number of separate meters on the property.",
     "type": "number",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 3,
+    "level": "silver"
   },
   "GreenEnergyEfficient": {
+    "definition": "Pick list of general green attributes such as energy efficient doors, or appliances without naming specific elements with ratings that may wane over time.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "GreenEnergyEfficient",
     "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Appliances",
       "Construction",
@@ -4973,26 +5489,26 @@
     ]
   },
   "GreenEnergyGeneration": {
+    "definition": "Methods of generating power that are included in the sale or lease.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "GreenEnergyGeneration",
     "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Solar",
       "Wind"
     ]
   },
   "GreenSustainability": {
+    "definition": "Pick list of sustainable elements used in the construction of the structure without naming specific elements with ratings that may wane over time.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "GreenSustainability",
     "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Conserving Methods",
       "Regionally-Sourced Materials",
@@ -5004,13 +5520,13 @@
     ]
   },
   "GreenWaterConservation": {
+    "definition": "Pick list of general water conserving attributes of the property such as landscaping or reclamation without naming specific elements with ratings that may wane over time.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "GreenWaterConservation",
     "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Water-Smart Landscaping",
       "Green Infrastructure",
@@ -5021,13 +5537,13 @@
     ]
   },
   "GreenIndoorAirQuality": {
+    "definition": "Pick list of indoor air quality measures without naming specific elements with ratings that may wane over time.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "GreenIndoorAirQuality",
     "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Contaminant Control",
       "Moisture Control",
@@ -5036,31 +5552,32 @@
     ]
   },
   "GreenLocation": {
+    "definition": "Pick list describing efficiencies involved with the property's location such as walkability or transportation proximity without naming specific elements with ratings that may wane over time.",
     "type": [
       "string"
     ],
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "silver"
   },
   "WalkScore": {
+    "definition": "A walkability index based on the time to walk from a property to near by essentials such as grocery stores, schools, churches, etc.  See www.walkscore.com for more information and requirements for using WalkScore.",
     "type": "number",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 3,
+    "level": "silver"
   },
   "HabitableResidenceYN": {
+    "definition": "Does the property include a structure that can be lived in.",
     "type": "boolean",
-    "level": "gold",
-    "path": "/Property"
+    "level": "gold"
   },
   "BodyType": {
+    "definition": "Type of mobile home.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "BodyType",
     "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Double Wide",
       "Expando",
@@ -5071,13 +5588,13 @@
     ]
   },
   "Skirt": {
+    "definition": "A list of types of mobile home skirting.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "Skirt",
     "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property",
     "enum": [
       "Aluminum",
       "Block",
@@ -5101,131 +5618,151 @@
     ]
   },
   "MobileDimUnits": {
+    "definition": "A pick list of the unit linear measurement.  i.e. feed, meters, yards, kilometers, miles, etc.",
     "type": "string",
     "maxLength": 25,
     "lookup": "LinearUnits",
     "level": "silver",
-    "path": "/Property",
     "enum": [
       "Feet",
       "Meters"
     ]
   },
   "ParkName": {
+    "definition": "Name of the mobile home park or corporate/commercial park.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "silver"
   },
   "ParkManagerName": {
+    "definition": "Name of the manager of the mobile home park.",
     "type": "string",
     "maxLength": 50,
-    "level": "silver",
-    "path": "/Property"
+    "level": "silver"
   },
   "ParkManagerPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "silver",
-    "path": "/Property"
+    "level": "silver"
   },
   "MobileHomeRemainsYN": {
+    "definition": "Is the mobile home to remain and be included in the sale of the property.",
     "type": "boolean",
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "NumberOfPads": {
+    "definition": "The number of pads or spaces in the mobile home park.",
     "type": "number",
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 3,
+    "level": "silver"
   },
   "SerialU": {
+    "definition": "Serial number of the mobile or manufactured home.  For the first or only unit/section use Serial U over Serial X or Serial XX.",
     "type": "string",
     "maxLength": 25,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "synonyms": [
+      "Unit1SerialNo"
+    ],
+    "level": "silver"
   },
   "DOH1": {
+    "definition": "Department of Housing decal number for the mobile or manufactured home.  For the first or only unit/section use DOH 1 over DOH 2 or 3.",
     "type": "string",
     "maxLength": 25,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "synonyms": [
+      "Unit1HCDHUDDECAL"
+    ],
+    "level": "silver"
   },
   "License1": {
+    "definition": "License number of the mobile or manufactured home.  Also known as the Department of Housing label/insignia number. For the first or only unit/section use License 1 over License 2 or 3.",
     "type": "string",
     "maxLength": 25,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "synonyms": [
+      "Unit1LicenseNo",
+      "Unit1Insignia"
+    ],
+    "level": "silver"
   },
   "SerialX": {
+    "definition": "Serial number of the mobile or manufactured home.  For two units/sections, Serial U should be used first, Serial X second over or Serial XX.",
     "type": "string",
     "maxLength": 25,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "synonyms": [
+      "Unit2SerialNo"
+    ],
+    "level": "silver"
   },
   "DOH2": {
+    "definition": "Department of Housing decal number for the mobile or manufactured home.  For two units/sections use DOH 1 and 2 over DOH 3.",
     "type": "string",
     "maxLength": 25,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "synonyms": [
+      "Unit2HCDHUDDECAL"
+    ],
+    "level": "silver"
   },
   "License2": {
+    "definition": "License number of the mobile or manufactured home.  Also known as the Department of Housing label/insignia number. For two units/sections use License 1 and 2 over License 3.",
     "type": "string",
     "maxLength": 25,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "synonyms": [
+      "Unit2LicenseNo",
+      "Unit2Insignia"
+    ],
+    "level": "silver"
   },
   "SerialXX": {
+    "definition": "Serial number of the mobile or manufactured home.  For two units/sections, Serial U should be used first, Serial X second over or Serial XX.",
     "type": "string",
     "maxLength": 25,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "synonyms": [
+      "Unit3SerialNo"
+    ],
+    "level": "silver"
   },
   "DOH3": {
+    "definition": "Department of Housing decal number for the mobile or manufactured home.  For two units/sections use DOH 1 and 2 over DOH 3.",
     "type": "string",
     "maxLength": 25,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "synonyms": [
+      "Unit3HCDHUDDECAL"
+    ],
+    "level": "silver"
   },
   "License3": {
+    "definition": "License number of the mobile or manufactured home.  Also known as the Department of Housing label/insignia number. For two units/sections use License 1 and 2 over License 3.",
     "type": "string",
     "maxLength": 25,
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "synonyms": [
+      "Unit3LicenseNo",
+      "Unit3Insignia"
+    ],
+    "level": "silver"
   },
   "AccessibilityFeatures": {
+    "definition": "A list or description of the accessibility features included in the sale/lease.",
     "type": [
       "string"
     ],
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "silver"
   },
   "RoomsTotal": {
+    "definition": "The number of rooms in the dwelling.",
     "type": "number",
-    "level": "gold",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 3,
+    "level": "gold"
   },
   "RoomType": {
+    "definition": "This field is a list of the types used in the rooms repeating elements.  The Type is a list of possible room types.  i.e. Bedroom, Bathroom, Living Room, Workshop, etc.  Each selected are expected to appear as the \"[type]\" in the related rooms fields in a flattened implementation (RETS 1.x only) of the room fields.  A relational implementation of rooms must omit the type from the field name and use RoomType to create a vertical representation of the various rooms.  \r\n**Note that Garage or Basement should not be added as a room type and are represented by the ParkingFeatures and Basement fields respectively.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "lookup": "RoomType",
     "level": "gold",
-    "payloads": "IDX",
-    "path": "/Property/Rooms",
     "repeating": true,
     "enum": [
       "Dining Room",
@@ -5300,28 +5837,29 @@
         ]
       },
       "Area": {
+        "definition": "[type] This field is a repeating element for each type of room selected in the RoomType field.  For every RoomType there are two possible implementations.  For a flat implementation (RETS 1.x only), each RoomType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. RoomKitchenArea.  \r\nA relational implementation of rooms must omit the type from the field name and use RoomType to create a vertical representation of the various rooms.  i.e. RoomArea with Kitchen in the relational table's RoomType field.",
         "type": "number",
-        "maxPrecision": "2",
-        "level": "gold",
-        "path": "/Property/Rooms"
+        "maxLength": 14,
+        "maxPrecision": 2,
+        "level": "gold"
       },
       "AreaUnits": {
+        "definition": "[type] This field is a repeating element for each type of room selected in the RoomType field.  For every RoomType there are two possible implementations.  For a flat implementation (RETS 1.x only), each RoomType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. RoomKitchenAreaUnits.  \r\nA relational implementation of rooms must omit the type from the field name and use RoomType to create a vertical representation of the various rooms.  i.e. RoomAreaUnits with Kitchen in the relational table's RoomType field.",
         "type": "string",
         "maxLength": 25,
         "lookup": "AreaUnits",
         "level": "gold",
-        "path": "/Property/Rooms",
         "enum": [
           "Square Feet",
           "Square Meters"
         ]
       },
       "AreaSource": {
+        "definition": "[type] This field is a repeating element for each type of room selected in the RoomType field.  For every RoomType there are two possible implementations.  For a flat implementation (RETS 1.x only), each RoomType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. RoomKitchenAreaSource.  \r\nA relational implementation of rooms must omit the type from the field name and use RoomType to create a vertical representation of the various rooms.  i.e. RoomAreaSource.",
         "type": "string",
         "maxLength": 50,
         "lookup": "AreaSource",
         "level": "gold",
-        "path": "/Property/Rooms",
         "enum": [
           "Appraiser",
           "Assessor",
@@ -5335,68 +5873,71 @@
         ]
       },
       "Dimensions": {
+        "definition": "[type] This field is a repeating element for each type of room selected in the RoomType field.  For every RoomType there are two possible implementations.  For a flat implementation (RETS 1.x only), each RoomType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. RoomKitchenDimensions.  \r\nA relational implementation of rooms must omit the type from the field name and use RoomType to create a vertical representation of the various rooms.  i.e. RoomDimensions with Kitchen in the relational table's RoomType field.",
         "type": "string",
         "maxLength": 50,
-        "level": "gold",
-        "path": "/Property/Rooms"
+        "level": "gold"
       },
       "Length": {
+        "definition": "[type] This field is a repeating element for each type of room selected in the RoomType field.  For every RoomType there are two possible implementations.  For a flat implementation (RETS 1.x only), each RoomType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. RoomKitchenLength.  \r\nA relational implementation of rooms must omit the type from the field name and use RoomType to create a vertical representation of the various rooms.  i.e. RoomLength with Kitchen in the relational table's RoomType field.",
         "type": "number",
-        "maxPrecision": "2",
-        "level": "gold",
-        "path": "/Property/Rooms"
+        "maxLength": 14,
+        "maxPrecision": 2,
+        "level": "gold"
       },
       "Width": {
+        "definition": "[type] This field is a repeating element for each type of room selected in the RoomType field.  For every RoomType there are two possible implementations.  For a flat implementation (RETS 1.x only), each RoomType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. RoomKitchenWidth.  \r\nA relational implementation of rooms must omit the type from the field name and use RoomType to create a vertical representation of the various rooms.  i.e. RoomWidth with Kitchen in the relational table's RoomType field.",
         "type": "number",
-        "maxPrecision": "2",
-        "level": "gold",
-        "path": "/Property/Rooms"
+        "maxLength": 14,
+        "maxPrecision": 2,
+        "level": "gold"
       },
       "LengthWidthUnits": {
+        "definition": "[type] This field is a repeating element for each type of room selected in the RoomType field.  For every RoomType there are two possible implementations.  For a flat implementation (RETS 1.x only), each RoomType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. RoomKitchenWidthUnits.  \r\nA relational implementation of rooms must omit the type from the field name and use RoomType to create a vertical representation of the various rooms.  i.e. RoomWidthUnits with Kitchen in the relational table's RoomType field.",
         "type": "string",
         "maxLength": 25,
         "lookup": "LinearUnits",
         "level": "gold",
-        "path": "/Property/Rooms",
         "enum": [
           "Feet",
           "Meters"
         ]
       },
       "LengthWidthSource": {
+        "definition": "[type] This field is a repeating element for each type of room selected in the RoomType field.  For every RoomType there are two possible implementations.  For a flat implementation (RETS 1.x only), each RoomType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. RoomKitchenWidthSource.  \r\nA relational implementation of rooms must omit the type from the field name and use RoomType to create a vertical representation of the various rooms.  i.e. RoomWidthSource with Kitchen in the relational table's RoomType field.",
         "type": "string",
         "maxLength": 50,
-        "level": "gold",
-        "path": "/Property/Rooms"
+        "level": "gold"
       },
       "Level": {
+        "definition": "[type] This field is a repeating element for each type of room selected in the RoomType field.  For every RoomType there are two possible implementations.  For a flat implementation (RETS 1.x only), each RoomType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. RoomKitchenLevel.  \r\nA relational implementation of rooms must omit the type from the field name and use RoomType to create a vertical representation of the various rooms.  i.e. RoomLevel with Kitchen in the relational table's RoomType field.",
         "type": "string",
         "maxLength": 25,
-        "level": "gold",
-        "path": "/Property/Rooms"
+        "level": "gold"
       },
       "Features": {
+        "definition": "[type] This field is a repeating element for each type of room selected in the RoomType field.  For every RoomType there are two possible implementations.  For a flat implementation (RETS 1.x only), each RoomType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. RoomKitchenFeatures.  \r\nA relational implementation of rooms must omit the type from the field name and use RoomType to create a vertical representation of the various rooms.  i.e. RoomFeatures with Kitchen in the relational table's RoomType field.",
         "type": [
           "string"
         ],
-        "level": "gold",
-        "path": "/Property/Rooms"
+        "maxLength": 1024,
+        "level": "gold"
       },
       "Description": {
+        "definition": "[type] This field is a repeating element for each type of room selected in the RoomType field.  For every RoomType there are two possible implementations.  For a flat implementation (RETS 1.x only), each RoomType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. RoomKitchenDescription.  \r\nA relational implementation of rooms must omit the type from the field name and use RoomType to create a vertical representation of the various rooms.  i.e. RoomDescription with Kitchen in the relational table's RoomType field.",
         "type": "string",
         "maxLength": 1024,
-        "level": "gold",
-        "path": "/Property/Rooms"
+        "level": "gold"
       }
     }
   ],
   "UnitTypeType": {
+    "definition": "This field is a list of the types used in the Unit Type repeating elements.  The Type is a list of possible Unit Types.  i.e. 1, 2, 3 or 2 Bed, Studio, Special Loft, etc.\r\nEach selected are expected to appear as the \"[type]\" in the related UnitType fields in a flattened implementation (RETS 1.x only) of the room fields.  A relational implementation of UnitTypes must omit the type from the field name and use UnitTypeType to create a vertical representation of the various unit types.  The fact that the field repeats the word \"type\" is intentional.",
     "type": [
       "string"
     ],
+    "maxLength": 1024,
     "level": "gold",
-    "payloads": "IDX",
-    "path": "/Property/UnitTypes",
     "repeating": true
   },
   "UnitTypes": [
@@ -5405,182 +5946,204 @@
         "type": "string"
       },
       "UnitsTotal": {
+        "definition": "[type] This field is a repeating element for each type of unit selected in the UnitType field.  For every UnitType there are two possible implementations.  For a flat implementation (RETS 1.x only), each UnitTypeType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. UnitTypeStudioUnitsTotal.  \r\nA relational implementation of UnitType must omit the type from the field name and use UnitTypeType to create a vertical representation of the various rooms.  i.e. UnitTypeUnitsTotal with Studio in the relational table's UnitType field.",
         "type": "number",
-        "level": "gold",
-        "path": "/Property/UnitTypes"
+        "maxLength": 3,
+        "level": "gold"
       },
       "BedsTotal": {
+        "definition": "[type] This field is a repeating element for each type of unit selected in the UnitType field.  For every UnitType there are two possible implementations.  For a flat implementation (RETS 1.x only), each UnitTypeType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. UnitTypeStudioBedsTotal.  \r\nA relational implementation of UnitType must omit the type from the field name and use UnitTypeType to create a vertical representation of the various rooms.  i.e. UnitTypeBedsTotal with Studio in the relational table's UnitType field.",
         "type": "number",
-        "level": "gold",
-        "path": "/Property/UnitTypes"
+        "maxLength": 3,
+        "level": "gold"
       },
       "BathsTotal": {
+        "definition": "[type] This field is a repeating element for each type of unit selected in the UnitType field.  For every UnitType there are two possible implementations.  For a flat implementation (RETS 1.x only), each UnitTypeType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. UnitTypeStudioBathsTotal.  \r\nA relational implementation of UnitType must omit the type from the field name and use UnitTypeType to create a vertical representation of the various rooms.  i.e. UnitTypeBathsTotal with Studio in the relational table's UnitType field.",
         "type": "number",
-        "level": "gold",
-        "path": "/Property/UnitTypes"
+        "maxLength": 3,
+        "level": "gold"
       },
       "Furnished": {
+        "definition": "[type] This field is a repeating element for each type of unit selected in the UnitType field.  For every UnitType there are two possible implementations.  For a flat implementation (RETS 1.x only), each UnitTypeType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. UnitTypeStudioFurnished.  \r\nA relational implementation of UnitType must omit the type from the field name and use UnitTypeType to create a vertical representation of the various rooms.  i.e. UnitTypeFurnished with Studio in the relational table's UnitType field.",
         "type": "string",
         "maxLength": 20,
-        "level": "gold",
-        "path": "/Property/UnitTypes"
+        "level": "gold"
       },
       "Description": {
+        "definition": "[type] This field is a repeating element for each type of unit selected in the UnitType field.  For every UnitType there are two possible implementations.  For a flat implementation (RETS 1.x only), each UnitTypeType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. UnitTypeStudioDescription.  \r\nA relational implementation of UnitType must omit the type from the field name and use UnitTypeType to create a vertical representation of the various rooms.  i.e. UnitTypeDescription with Studio in the relational table's UnitType field.",
         "type": "string",
         "maxLength": 1024,
-        "level": "gold",
-        "path": "/Property/UnitTypes"
+        "level": "gold"
       },
       "GarageSpaces": {
+        "definition": "[type] This field is a repeating element for each type of unit selected in the UnitType field.  For every UnitType there are two possible implementations.  For a flat implementation (RETS 1.x only), each UnitTypeType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. UnitTypeStudioGarageSpaces.  \r\nA relational implementation of UnitType must omit the type from the field name and use UnitTypeType to create a vertical representation of the various rooms.  i.e. UnitTypeGarageSpaces with Studio in the relational table's UnitType field.",
         "type": "number",
-        "maxPrecision": "2",
-        "level": "gold",
-        "path": "/Property/UnitTypes"
+        "maxLength": 14,
+        "maxPrecision": 2,
+        "level": "gold"
       },
       "GarageAttachedYN": {
+        "definition": "[type] This field is a repeating element for each type of unit selected in the UnitType field.  For every UnitType there are two possible implementations.  For a flat implementation (RETS 1.x only), each UnitTypeType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. UnitTypeStudioGarageAttachedYN.  \r\nA relational implementation of UnitType must omit the type from the field name and use UnitTypeType to create a vertical representation of the various rooms.  i.e. UnitTypeGarageAttachedYN with Studio in the relational table's UnitType field.",
         "type": "boolean",
-        "level": "gold",
-        "path": "/Property/UnitTypes"
+        "level": "gold"
       },
       "ActualRent": {
+        "definition": "[type] This field is a repeating element for each type of unit selected in the UnitType field.  For every UnitType there are two possible implementations.  For a flat implementation (RETS 1.x only), each UnitTypeType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. UnitTypeStudioActualRent.  \r\nA relational implementation of UnitType must omit the type from the field name and use UnitTypeType to create a vertical representation of the various rooms.  i.e. UnitTypeActualRent with Studio in the relational table's UnitType field.",
         "type": "number",
-        "maxPrecision": "2",
-        "level": "gold",
-        "path": "/Property/UnitTypes"
+        "maxLength": 14,
+        "maxPrecision": 2,
+        "level": "gold"
       },
       "TotalRent": {
+        "definition": "[type] This field is a repeating element for each type of unit selected in the UnitType field.  For every UnitType there are two possible implementations.  For a flat implementation (RETS 1.x only), each UnitTypeType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. UnitTypeStudioTotalRent.  \r\nA relational implementation of UnitType must omit the type from the field name and use UnitTypeType to create a vertical representation of the various rooms.  i.e. UnitTypeTotalRent with Studio in the relational table's UnitType field.",
         "type": "number",
-        "maxPrecision": "2",
-        "level": "gold",
-        "path": "/Property/UnitTypes"
+        "maxLength": 14,
+        "maxPrecision": 2,
+        "level": "gold"
       },
       "ProForma": {
+        "definition": "[type] This field is a repeating element for each type of unit selected in the UnitType field.  For every UnitType there are two possible implementations.  For a flat implementation (RETS 1.x only), each UnitTypeType used is expected to appear as the \"[type]\" in the related rooms field name.  i.e. UnitTypeStudioProForma.  \r\nA relational implementation of UnitType must omit the type from the field name and use UnitTypeType to create a vertical representation of the various rooms.  i.e. UnitTypeProForma with Studio in the relational table's UnitType field.",
         "type": "number",
-        "level": "gold",
-        "path": "/Property/UnitTypes"
+        "maxLength": 6,
+        "level": "gold"
       }
     }
   ],
   "Zoning": {
+    "definition": "A division of the city or county into areas of different permissible land uses. This Zone field should be used for the short code that is commonly used.  For full textual descriptions please use the ZoningDescription field.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "bronze"
   },
   "ZoningDescription": {
+    "definition": "A list of descriptions of the zoning of the property.  The zoning codes are often non-descriptive and variant. Zoning Description is a more descriptive form of the zoning for the property,  i.e. Agricultural, Residential, Rezone Possible, etc.  Specific zone codes must be added to the Zoning field.\r\n",
     "type": "string",
     "maxLength": 255,
-    "level": "bronze",
-    "payloads": "IDX",
-    "path": "/Property"
+    "level": "bronze"
   },
   "AdditionalParcelsYN": {
+    "definition": "Are there more than one parcel or lot included in the sale?",
     "type": "boolean",
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "AdditionalParcelsDescription": {
+    "definition": "If additional parcels are included in the sale, a list of those parcel's IDs separated by commas.  Do not include the first or primary parcel number, that should be located in the Parcel Number field.",
     "type": "string",
     "maxLength": 255,
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "PublicSurveySection": {
+    "definition": "This field specifically identifies the Section identified by the Public Land Survey System (PLSS).",
     "type": "string",
     "maxLength": 20,
-    "level": "gold",
-    "path": "/Property"
+    "level": "gold"
   },
   "PublicSurveyTownship": {
+    "definition": "This field specifically identifies the Township identified by the Public Land Survey System (PLSS).",
     "type": "string",
     "maxLength": 20,
-    "level": "gold",
-    "path": "/Property"
+    "level": "gold"
   },
   "PublicSurveyRange": {
+    "definition": "This field specifically identifies the Range identified by the Public Land Survey System (PLSS).",
     "type": "string",
     "maxLength": 20,
-    "level": "gold",
-    "path": "/Property"
+    "level": "gold"
   },
   "TaxLot": {
+    "definition": "A type of legal description for land in developed areas where streets or other rights-of-ways delineate large parcels of land referred to as divided into lots on which homes or other types of developments are built.  An example would read \"Lot 12 of Block 45 of Tract 3002 of the City of San Dunes, Desert County.\" Such a description would also reference an official plat filed with the clerk or recorder for that area which shows the location of the block and often the dimensions of the lots therein.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Property"
+    "synonyms": [
+      "Lot"
+    ],
+    "level": "bronze"
   },
   "TaxBlock": {
+    "definition": "A type of legal description for land in developed areas where streets or other rights-of-ways delineate large parcels of land referred to as divided into lots on which homes or other types of developments are built.  An example would read \"Lot 12 of Block 45 of Tract 3002 of the City of San Dunes, Desert County.\" Such a description would also reference an official plat filed with the clerk or recorder for that area which shows the location of the block and often the dimensions of the lots therein.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Property"
+    "synonyms": [
+      "Block"
+    ],
+    "level": "bronze"
   },
   "TaxTract": {
+    "definition": "A type of legal description for land in developed areas where streets or other rights-of-ways delineate large parcels of land referred to as divided into lots on which homes or other types of developments are built.  An example would read \"Lot 12 of Block 45 of Tract 3002 of the City of San Dunes, Desert County.\" Such a description would also reference an official plat filed with the clerk or recorder for that area which shows the location of the block and often the dimensions of the lots therein.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Property"
+    "synonyms": [
+      "Tract"
+    ],
+    "level": "bronze"
   },
   "TaxLegalDescription": {
+    "definition": "A type of legal description for land in developed areas where streets or other rights-of-ways delineate large parcels of land referred to as divided into lots on which homes or other types of developments are built.  An example would read \"Lot 12 of Block 45 of Tract 3002 of the City of San Dunes, Desert County.\" Such a description would also reference an official plat filed with the clerk or recorder for that area which shows the location of the block and often the dimensions of the lots therein. The text here is also an index into the property as described by the County Recorder.",
     "type": "string",
     "maxLength": 6000,
-    "level": "bronze",
-    "path": "/Property"
+    "synonyms": [
+      "LegalDescription"
+    ],
+    "level": "bronze"
   },
   "TaxAnnualAmount": {
+    "definition": "The annual property tax amount as of the last assessment made by the taxing authority.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "payloads": "IDX",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "TaxYear": {
+    "definition": "The year in with the last assessment of the property value/tax was made.",
     "type": "number",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 4,
+    "level": "silver"
   },
   "TaxAssessedValue": {
+    "definition": "The property value as of the last assessment made by the taxing authority.",
     "type": "number",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "level": "silver"
   },
   "TaxExemptions": {
+    "definition": "A list of tax exemptions as they relate to the property.",
     "type": [
       "string"
     ],
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 1024,
+    "level": "silver"
   },
   "TaxOtherAnnualAssessmentAmount": {
+    "definition": "Any other annual taxes, not including the tax reported in the TaxAmount field, as of the last assessment made by the taxing authority.",
     "type": "number",
-    "maxPrecision": "2",
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 14,
+    "maxPrecision": 2,
+    "level": "silver"
   },
   "TaxBookNumber": {
+    "definition": "Some systems of parcel identification incorporate a method which utilizes a county identifier, a tax book number, a tax map number and a parcel identification number.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "TaxMapNumber": {
+    "definition": "Some systems of parcel identification incorporate a method which utilizes a county identifier, a tax book number, a tax map number and a parcel identification number.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "TaxParcelLetter": {
+    "definition": "Some systems of parcel identification incorporate a method which utilizes a county identifier, a tax book number, a tax map number and a parcel identification number.",
     "type": "string",
     "maxLength": 25,
-    "level": "bronze",
-    "path": "/Property"
+    "level": "bronze"
   },
   "TaxStatusCurrent": {
+    "definition": "The current tax status of the mobile home in cases where the land or space is included in the sale.",
     "type": [
       "string"
     ],
-    "level": "silver",
-    "path": "/Property"
+    "maxLength": 50,
+    "level": "silver"
   }
 }

--- a/lib/savedsearch.json
+++ b/lib/savedsearch.json
@@ -1,116 +1,153 @@
 {
   "SavedSearchKey": {
+    "definition": "A unique identifier for this record from the immediate source. This may be a number, or string that can include URI or other forms.  This is the system you are connecting to and not necessarily the original source of the record.",
     "type": "string",
     "maxLength": 255,
     "level": "gold",
-    "path": "/SavedSearch",
     "primary": true
   },
   "SavedSearchKeyNumeric": {
+    "definition": "A unique identifier for this record from the immediate source. This may be a number, or string that can include URI or other forms.  This is the system you are connecting to and not necessarily the original source of the record.  This is the numeric only key and used as an alternative to the SavedSearchKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/SavedSearch"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "SavedSearchName": {
+    "definition": "The name given to the search by the member inputting the saved search.",
     "type": "string",
     "maxLength": 255,
-    "level": "gold",
-    "path": "/SavedSearch"
+    "level": "gold"
   },
   "SavedSearchDescription": {
+    "definition": "A textual description of the saved search input by the member who created the saved search.",
     "type": "string",
     "maxLength": 4000,
-    "level": "gold",
-    "path": "/SavedSearch"
+    "level": "gold"
   },
   "SavedSearchType": {
+    "definition": "Is the saved search used to pass criteria to be stored and executed by the client or is the saved search a key to be passed to the host for execution.  i.e. Client Receives Criteria, Host Returns Listings.  \r\n\r\nThis may be described at the record level with this field, or at some other level of implementation to be determined by RESO R&D.",
     "type": "string",
     "maxLength": 50,
-    "level": "gold",
-    "path": "/SavedSearch"
+    "level": "gold"
   },
   "OriginatingSystemKey": {
+    "definition": "The system key, a unique record identifier, from the Originating system.  The Originating system is the system with authoritative control over the record.  For example, the Multiple Listing Service where the Saved Search was input.  There may be cases where the Source System (how you received the record) is not the Originating System.  See Source System Key for more information. ",
     "type": "string",
     "maxLength": 255,
-    "level": "gold",
-    "path": "/SavedSearch"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "gold"
   },
   "OriginatingSystemName": {
+    "definition": "The name of the Originating record provider.  Most commonly the name of the MLS. The place where the Saved Search is originally input.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "gold",
-    "path": "/SavedSearch"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "gold"
   },
   "OriginatingSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Originating record provider.  The Originating system is the system with authoritative control over the record.  For example; the name of the MLS where the Saved Search was input.  In cases where the Originating system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/SavedSearch"
+    "level": "platinum"
   },
   "SourceSystemKey": {
+    "definition": "The system key, a unique record identifier, from the Source System.  The Source System is the system from which the record was directly received.  In cases where the Source System was not where the record originated (the authoritative system), see the Originating System fields. ",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/SavedSearch"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "silver"
   },
   "SourceSystemName": {
+    "definition": "The name of the Saved Search record provider.  The system from which the record was directly received.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/SavedSearch"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "silver"
   },
   "SourceSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Source record provider.  The source system is the system from which the record was directly received.  In cases where the source system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/SavedSearch"
+    "synonyms": [
+      "MLSID"
+    ],
+    "level": "platinum"
   },
   "SearchQuery": {
+    "definition": "Textual representation of the search performed by the member that was saved.  It is required to present in ODATA's $filter format.  Additional formats are under review.  See additional documentation for specific requirements for this field.",
     "type": "string",
     "maxLength": 8000,
-    "level": "gold",
-    "path": "/SavedSearch"
+    "synonyms": [
+      "SearchCriteria"
+    ],
+    "level": "gold"
   },
   "SearchQueryType": {
+    "definition": "A picklist of the type of query language used in the SearchQuery field.  i.e. DMQL2, $filter, etc.",
     "type": "string",
     "maxLength": 50,
-    "level": "gold",
-    "path": "/SavedSearch"
+    "level": "gold"
   },
   "SearchQueryExceptions": {
+    "definition": "A list of exceptions or errors with the given search query during it's creation by the host.  Analogous to an error code this is the host's opportunity to describe an inability to fully express a saved search under the constraints of the given protocol.  i.e. $filter.  The client may use this information to bring attention to the user about a given saved search and a need to review or recreate the search.",
     "type": "string",
     "maxLength": 50,
-    "level": "gold",
-    "path": "/SavedSearch"
+    "level": "gold"
   },
   "SearchQueryExceptionDetails": {
+    "definition": "A free text description used to expand on the SearchQueryExceptions selections made by the host.",
     "type": "string",
     "maxLength": 255,
-    "level": "gold",
-    "path": "/SavedSearch"
+    "level": "gold"
   },
   "SearchQueryHumanReadable": {
+    "definition": "A human readable version of the search query that is commonly used for display and may not contain all actual criteria.  For actual search criteria, use the SearchQuery field.",
     "type": "string",
     "maxLength": 255,
-    "level": "gold",
-    "path": "/SavedSearch"
+    "level": "gold"
   },
   "OriginalEntryTimestamp": {
+    "definition": "The transactional timestamp automatically recorded by the MLS system representing the date/time the listing was entered and made visible to members of the MLS.",
     "type": "date",
-    "level": "gold",
-    "path": "/SavedSearch"
+    "maxLength": 27,
+    "synonyms": [
+      "EntryDate",
+      "InputDate",
+      "DateTimeCreated",
+      "CreatedDate."
+    ],
+    "level": "gold"
   },
   "ModificationTimestamp": {
+    "definition": "The transactional timestamp automatically recorded by the MLS system representing the date/time the listing was last modified.",
     "type": "date",
-    "level": "gold",
-    "path": "/SavedSearch"
+    "maxLength": 27,
+    "synonyms": [
+      "ModificationDateTime",
+      "DateTimeModified",
+      "ModDate",
+      "DateMod",
+      "UpdateDate",
+      "UpdateTimestamp"
+    ],
+    "level": "gold"
   },
   "ResourceName": {
+    "definition": "The resource to which the SearchQuery criteria refers. i.e. Property, Open House, Agent, Office, Contact, etc.",
     "type": "string",
     "maxLength": 50,
     "lookup": "ResourceName",
     "level": "gold",
-    "path": "/SavedSearch",
     "enum": [
       "Property",
       "Member",
@@ -119,11 +156,11 @@
     ]
   },
   "ClassName": {
+    "definition": "The class or table to which the SearchQuery criteria refers.  i.e. Residential, Residential Lease, Income, Mobile, etc.",
     "type": "string",
     "maxLength": 50,
     "lookup": "ClassName",
     "level": "gold",
-    "path": "/SavedSearch",
     "enum": [
       "Business Opportunity",
       "Commercial Lease",
@@ -145,32 +182,40 @@
     ]
   },
   "MemberKey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the MemberKey is the system unique identifier from the system that the record was retrieved. This may be identical to the related xxxId.  This is a foreign key relating to the Member resource's MemberKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "gold",
-    "path": "/SavedSearch"
+    "level": "gold"
   },
   "MemberKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the MemberKey is the system unique identifier from the system that the record was retrieved. This may be identical to the related xxxId.  This is a foreign key relating to the Member resource's MemberKey.  This is the numeric only key and used as an alternative to the MemberKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/SavedSearch"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "OriginatingSystemMemberKey": {
+    "definition": "Unique identifier from the originating system which is commonly a key to that system.  In the case where data is passed through more than one system, this is the originating system key.  This is a foreign key relating to the system where this record was originated.",
     "type": "string",
     "maxLength": 255,
-    "level": "gold",
-    "path": "/SavedSearch"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "gold"
   },
   "OriginatingSystemMemberName": {
+    "definition": "The name of the originating record provider.  Most commonly the name of the MLS. The place where the listing is originally input by the member.  The legal name of the company.  To be used for display.",
     "type": "string",
     "maxLength": 255,
-    "level": "gold",
-    "path": "/SavedSearch"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "gold"
   },
   "MemberMlsId": {
+    "definition": "The local, well-known identifier for the member. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "gold",
-    "path": "/SavedSearch"
+    "level": "gold"
   }
 }

--- a/lib/team.json
+++ b/lib/team.json
@@ -1,105 +1,121 @@
 {
   "TeamKey": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the TeamKey is the system unique identifier from the system that the record was retrieved.",
     "type": "string",
     "maxLength": 255,
     "level": "platinum",
-    "path": "/Teams",
     "primary": true
   },
   "TeamKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, in aggregation systems, the TeamKey is the system unique identifier from the system that the record was retrieved.  This is the numeric only key and used as an alternative to the TeamKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Teams"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "OriginatingSystemKey": {
+    "definition": "The system key, a unique record identifier, from the Originating system.  The Originating system is the system with authoritative control over the record.  For example, the Multiple Listing Service where the Team was input.  There may be cases where the Source System (how you received the record) is not the Originating System.  See Source System Key for more information. ",
     "type": "string",
     "maxLength": 255,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "OriginatingSystemName": {
+    "definition": "The name of the Originating record provider.  Most commonly the name of the MLS. The place where the Team is originally input.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "platinum",
-    "path": "/Teams"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "platinum"
   },
   "OriginatingSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Originating record provider.  The Originating system is the system with authoritative control over the record.  For example; the name of the MLS where the Team was input.  In cases where the Originating system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "SourceSystemKey": {
+    "definition": "The system key, a unique record identifier, from the Source System.  The Source System is the system from which the record was directly received.  In cases where the Source System was not where the record originated (the authoritative system), see the Originating System fields. ",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Teams"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "silver"
   },
   "SourceSystemName": {
+    "definition": "The name of the Team record provider.  The system from which the record was directly received.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/Teams"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "silver"
   },
   "SourceSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Source record provider.  The source system is the system from which the record was directly received.  In cases where the source system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/Teams"
+    "synonyms": [
+      "MLSID"
+    ],
+    "level": "platinum"
   },
   "TeamName": {
+    "definition": "The name under which the team operates.  If a business this may be a DBA.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamDescription": {
+    "definition": "A description or marketing information about the team.",
     "type": "string",
     "maxLength": 1024,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamLeadKey": {
+    "definition": "The unique system identifier of the team's lead member.",
     "type": "string",
     "maxLength": 255,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamLeadKeyNumeric": {
+    "definition": "The unique system identifier of the team's lead member.  This is the numeric only key and used as an alternative to the TeamLeadKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/Teams"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "TeamLeadMlsId": {
+    "definition": "The local, well-known identifier for the Team Lead. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamLeadLoginId": {
+    "definition": "The ID used to logon to the MLS system.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamLeadNationalAssociationId": {
+    "definition": "The national association ID of the team lead.  i.e. in the U.S. is the NRDS number.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamLeadStateLicense": {
+    "definition": "The license of the Team Lead. Separate multiple licenses with a comma and space.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamLeadStateLicenseState": {
+    "definition": "The state in which the Team Lead is licensed.",
     "type": "string",
     "maxLength": 2,
     "lookup": "StateOrProvince",
     "level": "platinum",
-    "path": "/Teams",
     "enum": [
       "AK",
       "AL",
@@ -169,76 +185,76 @@
     ]
   },
   "TeamEmail": {
+    "definition": "The email address of the Team.",
     "type": "string",
     "maxLength": 80,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamPreferredPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamPreferredPhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamOfficePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamOfficePhoneExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamMobilePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamDirectPhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamFax": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamVoiceMail": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamVoiceMailExt": {
+    "definition": "The extension of the given phone number (if applicable).",
     "type": "string",
     "maxLength": 10,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamTollFreePhone": {
+    "definition": "North American 10 digit phone numbers should be in the format of ###-###-#### (separated by hyphens).  Other conventions should use the common local standard.  International numbers should be preceded by a plus symbol.",
     "type": "string",
     "maxLength": 16,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "SocialMediaType": {
+    "definition": "A list of types of sites, blog, social media, the Team URL or ID is referring to.  i.e. Website, Blog, Facebook, Twitter, LinkedIn, Skype, etc.,  This list is used to populate the Type with repeating Social Media URL or ID types.",
     "type": "string",
     "maxLength": 25,
     "level": "platinum",
-    "path": "/Teams",
     "repeating": true
   },
   "SocialMedias": [
@@ -247,37 +263,37 @@
         "type": "string"
       },
       "UrlOrId": {
+        "definition": "The website URL or ID of social media site or account of the Team.  This is a repeating element.  Replace [Type] with any of the options from the SocialMediaType field to create a unique field for that type of social media.  For example: SocialMediaFacebookUrlOrID, SocialMediaSkypeUrlOrID, etc.",
         "type": "string",
         "maxLength": 8000,
-        "level": "platinum",
-        "path": "/Teams"
+        "level": "platinum"
       }
     }
   ],
   "TeamAddress1": {
+    "definition": "The street number, direction, name and suffix of the Team.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamAddress2": {
+    "definition": "The unit/suite number of the Team.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamCity": {
+    "definition": "The city of the Team.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamStateOrProvince": {
+    "definition": "The state or province in which the Team is addressed.",
     "type": "string",
     "maxLength": 2,
     "lookup": "StateOrProvince",
     "level": "platinum",
-    "path": "/Teams",
     "enum": [
       "AK",
       "AL",
@@ -347,35 +363,42 @@
     ]
   },
   "TeamPostalCode": {
+    "definition": "The postal code of the Team.",
     "type": "string",
     "maxLength": 10,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamPostalCodePlus4": {
+    "definition": "The extension of the postal/zip code.  i.e. +4",
     "type": "string",
     "maxLength": 4,
-    "level": "platinum",
-    "path": "/Teams"
+    "level": "platinum"
   },
   "TeamCarrierRoute": {
+    "definition": "The group of addresses to which the USPS assigns the same code to aid in mail delivery. For the USPS, these codes are 9 digits: 5 numbers for the ZIP Code, one letter for the carrier route type, and 3 numbers for the carrier route number.",
     "type": "string",
     "maxLength": 9,
-    "level": "platinum",
-    "path": "/Teams"
+    "synonyms": [
+      "RR",
+      "CR"
+    ],
+    "level": "platinum"
   },
   "TeamCountyOrParish": {
+    "definition": "The county or parish in which the Team is addressed.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/Teams"
+    "synonyms": [
+      "County"
+    ],
+    "level": "platinum"
   },
   "TeamCountry": {
+    "definition": "The country abbreviation in a postal address.",
     "type": "string",
     "maxLength": 2,
     "lookup": "Country",
     "level": "platinum",
-    "path": "/Teams",
     "enum": [
       "AF",
       "AL",
@@ -627,24 +650,26 @@
     ]
   },
   "TeamStatus": {
+    "definition": "Is the account active, inactive or under disciplinary action.",
     "type": "string",
     "maxLength": 25,
     "lookup": "TeamStatus",
     "level": "platinum",
-    "path": "/Teams",
     "enum": [
       "Active",
       "Inactive"
     ]
   },
   "OriginalEntryTimestamp": {
+    "definition": "Date/time the roster (Team or office) record was originally input into the source system.",
     "type": "date",
-    "level": "platinum",
-    "path": "/Teams"
+    "maxLength": 27,
+    "level": "platinum"
   },
   "ModificationTimestamp": {
+    "definition": "Date/time the roster (Team or office) record was last modified.",
     "type": "date",
-    "level": "platinum",
-    "path": "/Teams"
+    "maxLength": 27,
+    "level": "platinum"
   }
 }

--- a/lib/teammember.json
+++ b/lib/teammember.json
@@ -1,104 +1,124 @@
 {
   "TeamMemberKey": {
+    "definition": "A system unique identifier. Specifically, the local key to the TeamMembers resource.",
     "type": "string",
     "maxLength": 255,
     "level": "platinum",
-    "path": "/TeamMembers",
     "primary": true
   },
   "TeamMemberKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, the local key to the TeamMembers resource.  This is the numeric only key and used as an alternative to the TeamKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/TeamMembers"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "OriginatingSystemKey": {
+    "definition": "The system key, a unique record identifier, from the Originating system.  The Originating system is the system with authoritative control over the record.  For example, the Multiple Listing Service where the Team Member was input.  There may be cases where the Source System (how you received the record) is not the Originating System.  See Source System Key for more information. ",
     "type": "string",
     "maxLength": 255,
-    "level": "platinum",
-    "path": "/TeamMembers"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "platinum"
   },
   "OriginatingSystemName": {
+    "definition": "The name of the Originating record provider.  Most commonly the name of the MLS. The place where the Team Member is originally input.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "platinum",
-    "path": "/TeamMembers"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "platinum"
   },
   "OriginatingSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Originating record provider.  The Originating system is the system with authoritative control over the record.  For example; the name of the MLS where the Team Member was input.  In cases where the Originating system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/TeamMembers"
+    "level": "platinum"
   },
   "SourceSystemKey": {
+    "definition": "The system key, a unique record identifier, from the Source System.  The Source System is the system from which the record was directly received.  In cases where the Source System was not where the record originated (the authoritative system), see the Originating System fields. ",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/TeamMembers"
+    "synonyms": [
+      "ProviderKey"
+    ],
+    "level": "silver"
   },
   "SourceSystemName": {
+    "definition": "The name of the Team Member record provider.  The system from which the record was directly received.  The legal name of the company.",
     "type": "string",
     "maxLength": 255,
-    "level": "silver",
-    "path": "/TeamMembers"
+    "synonyms": [
+      "ProviderName",
+      "MLSID"
+    ],
+    "level": "silver"
   },
   "SourceSystemID": {
+    "definition": "The RESO OUID's OrganizationUniqueId of the Source record provider.  The source system is the system from which the record was directly received.  In cases where the source system was not where the record originated (the authoritative system), see the Originating System fields.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/TeamMembers"
+    "synonyms": [
+      "MLSID"
+    ],
+    "level": "platinum"
   },
   "TeamKey": {
+    "definition": "A system unique identifier. Specifically, a foreign key referencing the Teams resource's primary key.",
     "type": "string",
     "maxLength": 255,
-    "level": "platinum",
-    "path": "/TeamMembers"
+    "level": "platinum"
   },
   "TeamKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, a foreign key referencing the Teams resource's primary key.  This is the numeric only key and used as an alternative to the TeamKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/TeamMembers"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "MemberKey": {
+    "definition": "A system unique identifier. Specifically, the foreign key relating to the Member resource's MemberKey.",
     "type": "string",
     "maxLength": 255,
-    "level": "platinum",
-    "path": "/TeamMembers"
+    "level": "platinum"
   },
   "MemberKeyNumeric": {
+    "definition": "A system unique identifier. Specifically, the foreign key relating to the Member resource's MemberKey.  This is the numeric only key and used as an alternative to the MemberKey field.",
     "type": "number",
-    "level": "platinum",
-    "path": "/TeamMembers"
+    "maxLength": 255,
+    "level": "platinum"
   },
   "MemberMlsId": {
+    "definition": "The local, well-known identifier for the member. This value may not be unique, specifically in the case of aggregation systems, this value should be the identifier from the original system.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/TeamMembers"
+    "level": "platinum"
   },
   "MemberLoginId": {
+    "definition": "The ID used to logon to the MLS system.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/TeamMembers"
+    "level": "platinum"
   },
   "TeamMemberNationalAssociationId": {
+    "definition": "The national association ID of the member.  i.e. in the U.S. is the NRDS number.",
     "type": "string",
     "maxLength": 25,
-    "level": "platinum",
-    "path": "/TeamMembers"
+    "level": "platinum"
   },
   "TeamMemberStateLicense": {
+    "definition": "The license of the member. Separate multiple licenses with a comma and space.",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/TeamMembers"
+    "level": "platinum"
   },
   "TeamMemberType": {
+    "definition": "The role of the member within the team.  i.e. team lead, principle, associate, assistant, etc.",
     "type": "string",
     "maxLength": 50,
     "lookup": "MemberType",
     "level": "platinum",
-    "path": "/TeamMembers",
     "enum": [
       "Association Staff",
       "Designated REALTOR Appraiser",
@@ -115,19 +135,21 @@
     ]
   },
   "TeamImpersonationLevel": {
+    "definition": "The level of impersonation the member is allowed within the team.  i.e. Impersonate (to work as the team), On Behalf (to show the team name, but also show the member's info, None (don't allow this member to appear as part of team).",
     "type": "string",
     "maxLength": 50,
-    "level": "platinum",
-    "path": "/TeamMembers"
+    "level": "platinum"
   },
   "OriginalEntryTimestamp": {
+    "definition": "Date/time the roster (member or office) record was originally input into the source system.",
     "type": "date",
-    "level": "platinum",
-    "path": "/TeamMembers"
+    "maxLength": 27,
+    "level": "platinum"
   },
   "ModificationTimestamp": {
+    "definition": "Date/time the roster (member or office) record was last modified.",
     "type": "date",
-    "level": "platinum",
-    "path": "/TeamMembers"
+    "maxLength": 27,
+    "level": "platinum"
   }
 }


### PR DESCRIPTION
At the minimum we should keep field definitions and synonyms. So as not to conflict with Mongo schema reserved option keys, we can prefix these with `dd`:

```js
HorseAmenities: {
  type: ['string'],
  ddDefinition: 'Horse-specific amenities',
}
```

- [x] Add synonyms
- [x] Add classes to Property
- [x] New enumerations
